### PR TITLE
fix: remove deprecated clip property from visually-hidden mixin

### DIFF
--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -25,7 +25,6 @@
 
 @mixin visually-hidden {
   border: 0;
-  clip: rect(1px, 1px, 1px, 1px);
   clip-path: inset(50%);
   height: 1px;
   margin: -1px;


### PR DESCRIPTION
Small fix that surfaced during previous stylelint setup work. Deprecated 'clip' property no longer needed per our browserlistrc