### PR TITLE
feat(focus): standardize focus ring system across all HDS components

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -10,19 +10,19 @@ When your PR changes something adopters will notice -- a new token, a CSS change
 
 You will be prompted to choose a bump type and write a summary. The summary goes directly into the changelog, so write it for adopters, not for maintainers.
 
-| Change type                             | Bump                                     |
-| --------------------------------------- | ---------------------------------------- |
-| New token, new component, new CSS class | `minor`                                  |
-| Bug fix, internal improvement           | `patch`                                  |
-| Removal or rename of a public symbol    | `minor` (pre-v1.0) / `major` (post-v1.0) |
+| Change type | Bump |
+| --- | --- |
+| New token, new component, new CSS class | `minor` |
+| Bug fix, internal improvement | `patch` |
+| Removal or rename of a public symbol | `minor` (pre-v1.0) / `major` (post-v1.0) |
+| Docs, Storybook, linter config, CI config, tooling, re-run of stale snapshot | none |
 
-## What does not need a changeset
-
-- Docs and Storybook-only changes (`*.md`, `*.mdx`, `*.stories.js`)
-- Linter config, CI config, tooling
+See [CONTRIBUTING.md](../CONTRIBUTING.md#semver-rubric) for the full rubric, including the `visual-breaking-change` label and deprecation grace period requirements.
 
 ## Releases
 
-A maintainer runs `npx changeset version` when ready to cut a release. This consumes all pending changesets, bumps the version, and updates CHANGELOG.md. Then `npm publish` cuts the release.
+Releases are automated via the CI release pipeline. When changeset files are present on `main`, CI opens (or updates) a "Version Packages" pull request. That PR shows the version bump and the generated CHANGELOG entry.
 
-From v0.8.0 onward this is automated via the CI release pipeline.
+**To cut a release:** merge the Version Packages PR when you are ready. CI will then build the dist, generate an SBOM, create a GitHub Release, and attach the artifacts. Do not merge it early; you can let changesets accumulate automatically until the release is intentional.
+
+`npm publish` is not yet wired (pending repo going public).

--- a/.changeset/all-seals-shave.md
+++ b/.changeset/all-seals-shave.md
@@ -2,9 +2,9 @@
 '@nasa/hds-core': minor
 ---
 
-form error style updates
+form style updates
 
-**Added:** `.usa-legend--large` selector is now part of the HDS authored surface.
+**Added:** `.usa-legend--large` and `.usa-radio__label-description` selectors are now part of the HDS authored surface.
 
 **Renamed:** `--hds-palette-error-border` is now `--hds-palette-error-indicator`. If you were referencing this property directly, update to the new name.
 

--- a/.changeset/all-seals-shave.md
+++ b/.changeset/all-seals-shave.md
@@ -2,7 +2,7 @@
 '@nasa/hds-core': minor
 ---
 
-minor: form error style updates
+form error style updates
 
 **Renamed:** `--hds-palette-error-border` is now `--hds-palette-error-indicator`. If you were referencing this property directly, update to the new name.
 

--- a/.changeset/all-seals-shave.md
+++ b/.changeset/all-seals-shave.md
@@ -4,10 +4,10 @@
 
 form error style updates
 
+**Added:** `.usa-legend--large` selector is now part of the HDS authored surface.
+
 **Renamed:** `--hds-palette-error-border` is now `--hds-palette-error-indicator`. If you were referencing this property directly, update to the new name.
 
 **Removed:** `--hds-border-radius-pill` custom property. Use a static value or define your own in `@layer site`.
 
 **Removed:** `.usa-file-input__target` selector (HDS override dropped).
-
-**Added:** `.usa-legend--large` selector is now part of the HDS authored surface.

--- a/.changeset/calm-rings-glow.md
+++ b/.changeset/calm-rings-glow.md
@@ -4,16 +4,20 @@
 
 focus ring system update
 
-**Added:** `hds-focus-ring-inline` mixin for inline and multiline elements such as links and breadcrumbs. Applies a dashed, palette-aware outline with `box-decoration-break: clone` so the ring wraps correctly across line breaks.
+**Added:** `hds-focus-ring-inline` mixin for inline and multiline elements such as links, unstyled buttons, and breadcrumbs. Renders a four-sided dashed ring via `repeating-linear-gradient` with the exact Figma `2,3` dash spec. Fragments per line box on multiline elements without requiring `box-decoration-break`.
 
 **Added:** `hds-focus-ring-size($circle-size-px)` mixin for circular focus rings on icon buttons. Pass the icon button diameter in pixels; the mixin calculates ring dimensions automatically.
 
+**Fixed:** SVG mask edges no longer clip on block focus rings. `overflow="visible"` added to both rect and circle SVGs so the outer half of the 1px stroke paints into the pseudo-element's existing `inset` space.
+
 **Changed:** `hds-focus-ring` mixin signature. The `$width`, `$method`, and `$offset` parameters have been removed. The new signature is `hds-focus-ring($color, $shape, $pseudo, $circle-size-px)`. If you were calling this mixin with non-default parameters, update your call sites.
+
+**Changed:** `hds-focus-ring` and `hds-focus-ring-size` mixin defaults for `$pseudo` flipped from `'after'` to `'before'`. Component-owned `::after` icons (accordion chevrons, pagination arrows, primary arrow circles) were being clobbered by the global focus rule's pseudo-element. If you were calling either mixin without passing `$pseudo`, the focus ring now renders on `::before` instead of `::after`. Pass `$pseudo: 'after'` explicitly to restore the previous behavior.
+
+**Changed:** `hds-link-appearance` and `hds-link-hover` mixins now render the dashed underline via `repeating-linear-gradient` instead of `text-decoration`. This matches the Figma `2,3` dash spec exactly and aligns the underline and focus ring to the same coordinate origin, so the bottom edge does not shift when focus is applied. Always-on `padding: 0 4px` and `margin: 0 -4px` provide horizontal breathing room for the focus ring without shifting text layout.
 
 **Changed:** Stock `<button>` and `a.button` (the base reset that activates with `$theme-global-content-styles: true`) now share hover, active, and focus styling with `.usa-button` via the new internal `button-interactive-states` mixin. Stock buttons previously diverged: a 2px solid focus outline and `filter: brightness()` hover. They now match `.usa-button` exactly (NASA Red Shade hover/active, 1px dashed bold focus ring).
 
-**Changed:** Focused links (`a:focus-visible`) and unstyled buttons (`.usa-button--unstyled:focus-visible`) no longer show a text underline. The dashed outline ring replaces it.
+**Changed:** Focused links (`a:focus-visible`) and unstyled buttons (`.usa-button--unstyled:focus-visible`) no longer show a text underline. The focus ring's bottom edge serves as the underline indicator.
 
 **Removed:** `$hds-focus-widths` Sass map (`thin: 1px`, `thick: 2px`). The unified focus ring system bakes 1px directly into the SVG mask, so the map had no remaining consumers. If you were importing it, inline the pixel value at the call site.
-
-**Changed:** `hds-focus-ring` and `hds-focus-ring-size` mixin defaults for `$pseudo` flipped from `'after'` to `'before'`. Component-owned `::after` icons (accordion chevrons, pagination arrows, primary arrow circles) were being clobbered by the global focus rule's pseudo-element. If you were calling either mixin without passing `$pseudo`, the focus ring now renders on `::before` instead of `::after`. Pass `$pseudo: 'after'` explicitly to restore the previous behavior.

--- a/.changeset/calm-rings-glow.md
+++ b/.changeset/calm-rings-glow.md
@@ -15,3 +15,5 @@ focus ring system update
 **Changed:** Focused links (`a:focus-visible`) and unstyled buttons (`.usa-button--unstyled:focus-visible`) no longer show a text underline. The dashed outline ring replaces it.
 
 **Removed:** `$hds-focus-widths` Sass map (`thin: 1px`, `thick: 2px`). The unified focus ring system bakes 1px directly into the SVG mask, so the map had no remaining consumers. If you were importing it, inline the pixel value at the call site.
+
+**Changed:** `hds-focus-ring` and `hds-focus-ring-size` mixin defaults for `$pseudo` flipped from `'after'` to `'before'`. Component-owned `::after` icons (accordion chevrons, pagination arrows, primary arrow circles) were being clobbered by the global focus rule's pseudo-element. If you were calling either mixin without passing `$pseudo`, the focus ring now renders on `::before` instead of `::after`. Pass `$pseudo: 'after'` explicitly to restore the previous behavior.

--- a/.changeset/calm-rings-glow.md
+++ b/.changeset/calm-rings-glow.md
@@ -1,0 +1,13 @@
+---
+'@nasa/hds-core': minor
+---
+
+focus ring system update
+
+**Changed:** `hds-focus-ring` mixin signature. The `$width`, `$method`, and `$offset` parameters have been removed. The new signature is `hds-focus-ring($color, $shape, $pseudo, $circle-size-px)`. If you were calling this mixin with non-default parameters, update your call sites.
+
+**Added:** `hds-focus-ring-inline` mixin for inline and multiline elements such as links and breadcrumbs. Applies a dashed, palette-aware outline with `box-decoration-break: clone` so the ring wraps correctly across line breaks.
+
+**Added:** `hds-focus-ring-size($circle-size-px)` mixin for circular focus rings on icon buttons. Pass the icon button diameter in pixels; the mixin calculates ring dimensions automatically.
+
+**Changed:** Focused links (`a:focus-visible`) and unstyled buttons (`.usa-button--unstyled:focus-visible`) no longer show a text underline. The dashed outline ring replaces it.

--- a/.changeset/calm-rings-glow.md
+++ b/.changeset/calm-rings-glow.md
@@ -2,22 +2,12 @@
 '@nasa/hds-core': minor
 ---
 
-focus ring system update
+Focus ring system — breaking changes
 
-**Added:** `hds-focus-ring-inline` mixin for inline and multiline elements such as links, unstyled buttons, and breadcrumbs. Renders a four-sided dashed ring via `repeating-linear-gradient` with the exact Figma `2,3` dash spec. Fragments per line box on multiline elements without requiring `box-decoration-break`.
+**Breaking: `hds-focus-ring` signature changed.** The `$width`, `$method`, and `$offset` parameters have been removed. New signature: `hds-focus-ring($color, $shape, $pseudo, $circle-size-px)`. Update any call sites that passed non-default parameters.
 
-**Added:** `hds-focus-ring-size($circle-size-px)` mixin for circular focus rings on icon buttons. Pass the icon button diameter in pixels; the mixin calculates ring dimensions automatically.
+**Breaking: `hds-focus-ring` and `hds-focus-ring-size` default `$pseudo` flipped from `'after'` to `'before'`.** If you were calling either mixin without an explicit `$pseudo` argument, the focus ring now renders on `::before`. Pass `$pseudo: 'after'` to restore the previous behavior.
 
-**Fixed:** SVG mask edges no longer clip on block focus rings. `overflow="visible"` added to both rect and circle SVGs so the outer half of the 1px stroke paints into the pseudo-element's existing `inset` space.
+**Breaking: `$hds-focus-widths` Sass map removed.** The unified ring system bakes 1px directly into the SVG mask. Inline the value at any call sites that referenced this map.
 
-**Changed:** `hds-focus-ring` mixin signature. The `$width`, `$method`, and `$offset` parameters have been removed. The new signature is `hds-focus-ring($color, $shape, $pseudo, $circle-size-px)`. If you were calling this mixin with non-default parameters, update your call sites.
-
-**Changed:** `hds-focus-ring` and `hds-focus-ring-size` mixin defaults for `$pseudo` flipped from `'after'` to `'before'`. Component-owned `::after` icons (accordion chevrons, pagination arrows, primary arrow circles) were being clobbered by the global focus rule's pseudo-element. If you were calling either mixin without passing `$pseudo`, the focus ring now renders on `::before` instead of `::after`. Pass `$pseudo: 'after'` explicitly to restore the previous behavior.
-
-**Changed:** `hds-link-appearance` and `hds-link-hover` mixins now render the dashed underline via `repeating-linear-gradient` instead of `text-decoration`. This matches the Figma `2,3` dash spec exactly and aligns the underline and focus ring to the same coordinate origin, so the bottom edge does not shift when focus is applied. Always-on `padding: 0 4px` and `margin: 0 -4px` provide horizontal breathing room for the focus ring without shifting text layout.
-
-**Changed:** Stock `<button>` and `a.button` (the base reset that activates with `$theme-global-content-styles: true`) now share hover, active, and focus styling with `.usa-button` via the new internal `button-interactive-states` mixin. Stock buttons previously diverged: a 2px solid focus outline and `filter: brightness()` hover. They now match `.usa-button` exactly (NASA Red Shade hover/active, 1px dashed bold focus ring).
-
-**Changed:** Focused links (`a:focus-visible`) and unstyled buttons (`.usa-button--unstyled:focus-visible`) no longer show a text underline. The focus ring's bottom edge serves as the underline indicator.
-
-**Removed:** `$hds-focus-widths` Sass map (`thin: 1px`, `thick: 2px`). The unified focus ring system bakes 1px directly into the SVG mask, so the map had no remaining consumers. If you were importing it, inline the pixel value at the call site.
+**Breaking: `hds-link-appearance` and `hds-link-hover` now render underlines via `repeating-linear-gradient` instead of `text-decoration`.** If you were overriding `text-decoration` on elements that receive these mixins, those overrides no longer apply. Use `background-image: none` to suppress the underline instead.

--- a/.changeset/calm-rings-glow.md
+++ b/.changeset/calm-rings-glow.md
@@ -4,10 +4,14 @@
 
 focus ring system update
 
-**Changed:** `hds-focus-ring` mixin signature. The `$width`, `$method`, and `$offset` parameters have been removed. The new signature is `hds-focus-ring($color, $shape, $pseudo, $circle-size-px)`. If you were calling this mixin with non-default parameters, update your call sites.
-
 **Added:** `hds-focus-ring-inline` mixin for inline and multiline elements such as links and breadcrumbs. Applies a dashed, palette-aware outline with `box-decoration-break: clone` so the ring wraps correctly across line breaks.
 
 **Added:** `hds-focus-ring-size($circle-size-px)` mixin for circular focus rings on icon buttons. Pass the icon button diameter in pixels; the mixin calculates ring dimensions automatically.
 
+**Changed:** `hds-focus-ring` mixin signature. The `$width`, `$method`, and `$offset` parameters have been removed. The new signature is `hds-focus-ring($color, $shape, $pseudo, $circle-size-px)`. If you were calling this mixin with non-default parameters, update your call sites.
+
+**Changed:** Stock `<button>` and `a.button` (the base reset that activates with `$theme-global-content-styles: true`) now share hover, active, and focus styling with `.usa-button` via the new internal `button-interactive-states` mixin. Stock buttons previously diverged: a 2px solid focus outline and `filter: brightness()` hover. They now match `.usa-button` exactly (NASA Red Shade hover/active, 1px dashed bold focus ring).
+
 **Changed:** Focused links (`a:focus-visible`) and unstyled buttons (`.usa-button--unstyled:focus-visible`) no longer show a text underline. The dashed outline ring replaces it.
+
+**Removed:** `$hds-focus-widths` Sass map (`thin: 1px`, `thick: 2px`). The unified focus ring system bakes 1px directly into the SVG mask, so the map had no remaining consumers. If you were importing it, inline the pixel value at the call site.

--- a/.changeset/light-islands-flow.md
+++ b/.changeset/light-islands-flow.md
@@ -1,0 +1,13 @@
+---
+'@nasa/hds-core': patch
+---
+
+Focus ring system — bug fixes
+
+**Fixed: SVG mask edges no longer clip on block focus rings.** `overflow="visible"` added to rect and circle SVGs.
+
+**Fixed: Breadcrumb focus ring no longer clips at list edges.** USWDS sets `overflow: hidden` on `.usa-breadcrumb__list` for truncation; HDS Core now overrides to `overflow: visible` while preserving truncation behavior.
+
+**Fixed: Stock `<button>` and `a.button` now match `.usa-button`** for hover, active, and focus states via a shared internal mixin. Previously diverged with a 2px solid outline and `filter: brightness()` hover.
+
+**Fixed: Focused links and unstyled buttons no longer show a text underline on `:focus-visible`.** The focus ring's bottom edge serves as the underline indicator.

--- a/.changeset/quiet-arrows-land.md
+++ b/.changeset/quiet-arrows-land.md
@@ -1,0 +1,13 @@
+---
+'@nasa/hds-core': patch
+---
+
+primary arrow button + external link fixes
+
+**Fixed:** `.hds-btn--primary.usa-link--external` rendered with a clipped red circle because `.usa-link--external::after`'s base `mask-image` was leaking through the shared pseudo-element slot. The external override now explicitly sets `mask-image: none`.
+
+**Fixed:** `.hds-btn--primary` size variants (`--lg`, `--xl`, `--2xl`) now scale the gap between text and circle (4px → 8px at lg+) to match the Figma reference instead of staying pinned at 4px.
+
+**Fixed:** External diagonal glyph appeared smaller than the internal right-facing glyph at matching sizes. Both inline SVGs now use the HDS filled-icon paths (`arrow-line-right`, `arrow-line-diagonal`) so their drawn extents match.
+
+**Fixed:** `.usa-link--external::after` reset `margin-top: 0.7ex` leaked from USWDS's `external-link()` mixin, shifting the arrow off the text baseline. The base rule now sets `margin: 0`.

--- a/.changeset/quiet-arrows-land.md
+++ b/.changeset/quiet-arrows-land.md
@@ -11,3 +11,5 @@ primary arrow button + external link fixes
 **Fixed:** External diagonal glyph appeared smaller than the internal right-facing glyph at matching sizes. Both inline SVGs now use the HDS filled-icon paths (`arrow-line-right`, `arrow-line-diagonal`) so their drawn extents match.
 
 **Fixed:** `.usa-link--external::after` reset `margin-top: 0.7ex` leaked from USWDS's `external-link()` mixin, shifting the arrow off the text baseline. The base rule now sets `margin: 0`.
+
+**Fixed:** `.hds-btn--primary` focus ring switched from `hds-focus-ring-inline` to `hds-focus-ring` with per-size `inset` overrides matching Figma spacing (4px top/bottom, 6px left/right on default/sm/xs; 6px all sides on lg/xl; 6px top/bottom, 8px left/right on 2xl).

--- a/.changeset/silver-points-accept.md
+++ b/.changeset/silver-points-accept.md
@@ -1,0 +1,9 @@
+---
+'@nasa/hds-core': minor
+---
+
+Focus ring system — new mixins
+
+**Added: `hds-focus-ring-inline` mixin** for inline and multiline elements (links, unstyled buttons, breadcrumbs). Renders a four-sided dashed ring via `repeating-linear-gradient` matching the Figma `2,3` dash spec. Fragments correctly per line box on wrapped text.
+
+**Added: `hds-focus-ring-size($circle-size-px)` mixin** for overriding circle ring geometry on icon button size modifiers without re-declaring the full mixin.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Capture the committed version BEFORE changesets/action runs.
+      # The action modifies package.json locally when it prepares the Version
+      # Packages PR, so reading the file after the action would give the
+      # bumped version even when no version bump was merged to main.
+      - name: Capture committed package version
+        id: committed-version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       - name: Changesets -- manage Version Packages PR
         uses: changesets/action@v1
         with:
@@ -46,12 +54,12 @@ jobs:
 
       # Everything below runs only when a version bump landed on main
       # (i.e., the Version Packages PR was just merged).
-      # Detection: compare package.json version against latest git tag.
+      # Detection: compare the committed package.json version against the latest git tag.
 
       - name: Check if version was bumped
         id: version-check
         run: |
-          CURRENT=$(node -p "require('./package.json').version")
+          CURRENT="${{ steps.committed-version.outputs.version }}"
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           LATEST_VERSION=${LATEST_TAG#v}
           if [ "$CURRENT" != "$LATEST_VERSION" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/main'
+    if: "github.actor != 'dependabot[bot]' && github.ref == 'refs/heads/main'"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -54,21 +54,22 @@ jobs:
 
       # Everything below runs only when a version bump landed on main
       # (i.e., the Version Packages PR was just merged).
-      # Detection: compare the committed package.json version against the latest git tag.
+      # Detection: check whether an exact tag for the committed version already
+      # exists. Using git tag -l rather than git describe avoids a false-positive
+      # on repos with no prior tags (git describe falls back to v0.0.0, which
+      # never matches any real version).
 
       - name: Check if version was bumped
         id: version-check
         run: |
           CURRENT="${{ steps.committed-version.outputs.version }}"
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          LATEST_VERSION=${LATEST_TAG#v}
-          if [ "$CURRENT" != "$LATEST_VERSION" ]; then
+          if git tag -l "v${CURRENT}" | grep -q "v${CURRENT}"; then
+            echo "released=false" >> $GITHUB_OUTPUT
+            echo "Tag v${CURRENT} already exists -- skipping release steps"
+          else
             echo "released=true" >> $GITHUB_OUTPUT
             echo "version=$CURRENT" >> $GITHUB_OUTPUT
-            echo "Version bump detected: $LATEST_VERSION -> $CURRENT"
-          else
-            echo "released=false" >> $GITHUB_OUTPUT
-            echo "No version change -- skipping release steps"
+            echo "No tag for v${CURRENT} found -- release steps will run"
           fi
 
       - name: Build
@@ -83,12 +84,8 @@ jobs:
 
       - name: Get changelog entry
         if: steps.version-check.outputs.released == 'true'
-        id: changelog
         run: |
-          NOTES=$(awk '/^## /{found++} found==1{print} found==2{exit}' CHANGELOG.md)
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          echo "$NOTES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          awk '/^## /{found++} found==1{print} found==2{exit}' CHANGELOG.md > release-notes.md
 
       - name: Create dist zip
         if: steps.version-check.outputs.released == 'true'
@@ -102,6 +99,6 @@ jobs:
         run: |
           gh release create "v${{ steps.version-check.outputs.version }}" \
             --title "v${{ steps.version-check.outputs.version }}" \
-            --notes "${{ steps.changelog.outputs.notes }}" \
+            --notes-file release-notes.md \
             "hds-core-v${{ steps.version-check.outputs.version }}-dist.zip#dist artifacts" \
             "sbom.json#SBOM (CycloneDX)"

--- a/.storybook/DocsContainer.jsx
+++ b/.storybook/DocsContainer.jsx
@@ -1,0 +1,59 @@
+// DocsContainer.jsx
+// Custom docs page wrapper for Storybook.
+//
+// Currently adds an "Edit this page on GitHub" link at the bottom of every
+// docs page (MDX guidance pages and foundation pages alike).
+//
+// This is the foundation for the full Storybook footer planned once the repo
+// is public and the Pages deploy infrastructure is in place. The full footer
+// will also include the page's last-edited date and editor username, HDS Core
+// responsible official, required links, and docs version label.
+//
+// USAGE: Referenced from preview.js via parameters.docs.container.
+// See preview.js for the one-line wire-up.
+
+import React from 'react';
+import { DocsContainer as BaseDocsContainer } from '@storybook/addon-docs/blocks';
+
+const REPO = 'https://github.com/nasa/hds-core';
+
+// Temporary: points to docs/ocomm-review for OCOMM pre-v1.0 review.
+// Restore to 'main' when branch protection is in place.
+// Full footer rehaul can derive this from git context at build time.
+const EDIT_BRANCH = 'docs/ocomm-review';
+
+function getEditUrl(context) {
+  const storyId = new URLSearchParams(window.location.search).get('id');
+
+  if (storyId) {
+    const entry = context?.store?.storyIndex?.entries?.[storyId];
+    if (entry?.importPath) {
+      return `${REPO}/edit/${EDIT_BRANCH}/${entry.importPath.replace(/^\.\//, '')}`;
+    }
+  }
+
+  // Fallback: link to the stories directory.
+  return `${REPO}/tree/${EDIT_BRANCH}/stories`;
+}
+
+export function DocsContainer({ children, context, ...props }) {
+  const editUrl = getEditUrl(context);
+
+  return (
+    <BaseDocsContainer context={context} {...props}>
+      {children}
+      <div
+        style={{
+          marginTop: '3rem',
+          paddingTop: '1.25rem',
+          borderTop: '1px solid rgba(0, 0, 0, 0.1)',
+          fontSize: '13px',
+        }}
+      >
+        <a href={editUrl} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit' }}>
+          Edit this page on GitHub ↗
+        </a>
+      </div>
+    </BaseDocsContainer>
+  );
+}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,6 +8,7 @@
 // ============================================================
 
 import initInPageNav from './utils/in-page-nav-init';
+import { DocsContainer } from './DocsContainer.jsx';
 
 const preview = {
   parameters: {
@@ -22,6 +23,7 @@ const preview = {
       },
     },
     docs: {
+      container: DocsContainer,
       codePanel: true,
       toc: {
         headingSelector: 'h2, h3',

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ These prevent silent parser failures:
 - Implementation: `_hds-mixins.scss` (mixins), `base/_focus.scss` (global baseline). See ARCHITECTURE.md for signatures and application methods, DESIGN.md for treatment rationale.
 - When adding focus rings to a new component, use the existing mixin infrastructure (`hds-focus-ring`, `hds-focus-ring-inline`, `hds-focus-ring-size`). If you cannot match the Figma spec with the existing mixins, flag to the user for a strategic call — do not hardcode focus styles at the component level or silently modify the mixin.
 - Form text inputs, textareas, and selects use a solid blue 2px border highlight, not the dashed system. Intentional, tracked in Issue #20.
-- `.hds-btn-icon--interactive` is the only icon button role with a hardcoded ring (Carbon 40, exempt from palette system). All other roles use palette-aware `hds-focus-ring()`.
+- `.hds-btn-icon--interactive` uses the same `hds-focus-ring($shape: 'circle')` as all other icon button roles but overrides `::before { background-color }` with a hardcoded `$hds-color-carbon-40`. These buttons live over images, video, and 3D content where palette containers don't apply.
 
 ## Verification rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,12 +203,12 @@ These prevent silent parser failures:
 - **Form error hover:** Red error border lost on hover due to specificity mismatch (hover 0,3,0 vs error 0,1,0).
 - **Table sort focus:** Focus ring clipped by `mask-image`. Needs surface-inverse treatment per Figma.
 
-### Focus rings — partially stabilized
+### Focus rings
 
-- Issue #40 (in progress): Width and offset standardized to 1px, hardcoded in `hds-focus-ring` mixin. Focus width/offset tokens removed from `tokens.json`. Remaining open question: whether `focus.*` color tokens stabilize or stay internal.
-- Issue #20: Form input focus uses separate solid blue highlight, not the dashed outline system.
-- Icon buttons hardcode Carbon 40 dashed ring, exempt from palette system. This is intentional.
-- Do not modify focus ring behavior without explicit permission — remaining inconsistencies are under CD review.
+- Implementation: `_hds-mixins.scss` (mixins), `base/_focus.scss` (global baseline). See ARCHITECTURE.md for signatures and application methods, DESIGN.md for treatment rationale.
+- When adding focus rings to a new component, use the existing mixin infrastructure (`hds-focus-ring`, `hds-focus-ring-inline`, `hds-focus-ring-size`). If you cannot match the Figma spec with the existing mixins, flag to the user for a strategic call — do not hardcode focus styles at the component level or silently modify the mixin.
+- Form text inputs, textareas, and selects use a solid blue 2px border highlight, not the dashed system. Intentional, tracked in Issue #20.
+- `.hds-btn-icon--interactive` is the only icon button role with a hardcoded ring (Carbon 40, exempt from palette system). All other roles use palette-aware `hds-focus-ring()`.
 
 ## Verification rules
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,17 +226,17 @@ HDS focus rings target a 1px dashed Figma spec (`2,3` dasharray) while sidestepp
 
 All defined in `_hds-mixins.scss` (public Sass surface).
 
-| Mixin                   | Signature                                                                    |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| `hds-focus-ring`        | `($color: 'default', $shape: 'rect', $pseudo: 'after', $circle-size-px: 24)` |
-| `hds-focus-ring-size`   | `($circle-size-px, $pseudo: 'after')`                                        |
-| `hds-focus-ring-inline` | `($color: 'default')`                                                        |
+| Mixin                   | Signature                                                                     |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `hds-focus-ring`        | `($color: 'default', $shape: 'rect', $pseudo: 'before', $circle-size-px: 24)` |
+| `hds-focus-ring-size`   | `($circle-size-px, $pseudo: 'before')`                                        |
+| `hds-focus-ring-inline` | `($color: 'default')`                                                         |
 
 `hds-focus-ring` parameters:
 
 - **`$color`** — `'default'`, `'bold'`, `'subtle'`, or `'minimal'`. Resolves to the matching `--hds-palette-focus-*` custom property with a light-scheme fallback for non-palette contexts.
 - **`$shape`** — `'rect'` (inherits the host's `border-radius`) or `'circle'`.
-- **`$pseudo`** — `'after'` (default) or `'before'`. Use `'before'` when the host already uses `::after` for another purpose. Current consumers: accordion chevron, in-page nav active bar, pagination current-page bar, primary arrow button.
+- **`$pseudo`** — `'before'` (default) or `'after'`. Default is `'before'` because trailing icons (chevrons, active bars, arrows) conventionally live on `::after`; painting the focus ring on `::before` keeps the global focus rule in `base/_focus.scss` from clobbering those icons. Pass `'after'` only when a host already uses `::before` for something else.
 - **`$circle-size-px`** — host size in pixels. Only used when `$shape: 'circle'`. The mask SVG is generated at compile time to match exactly, eliminating `calc()`, percentage, and transform-based rounding bugs.
 
 `hds-focus-ring-size` overrides ring geometry on icon button size modifiers (`--xs`, `--lg`, etc.) without re-declaring the full mixin.
@@ -245,7 +245,7 @@ All defined in `_hds-mixins.scss` (public Sass surface).
 
 The mixin you call depends on the host element's layout:
 
-1. **Block elements via SVG mask** — `hds-focus-ring()` on the host. Sets `position: relative`, kills the native outline, paints the ring through an absolute `::after` (or `::before`) pseudo-element with a `mask-image` data-URI SVG. The `2,3` dash pattern is baked into the SVG because native CSS `dashed` produces a different rhythm at 1px. Used by `.usa-button`, icon button circles, accordion headings, pagination links, in-page nav links, primary arrow button.
+1. **Block elements via SVG mask** — `hds-focus-ring()` on the host. Sets `position: relative`, kills the native outline, paints the ring through an absolute `::before` (or `::after`) pseudo-element with a `mask-image` data-URI SVG. The `2,3` dash pattern is baked into the SVG because native CSS `dashed` produces a different rhythm at 1px. Used by `.usa-button`, icon button circles, accordion headings, pagination links, in-page nav links, primary arrow button.
 2. **Inline text via native outline** — `hds-focus-ring-inline()` on the host. Native `outline: 1px dashed` plus `box-decoration-break: clone` so the ring wraps cleanly across line breaks. Used by `.usa-link`, `.usa-button--unstyled`, `.usa-breadcrumb__link`.
 3. **Form controls via sibling outline** — checkbox and radio labels apply `display: inline-flex`, lock the hidden input with `position: absolute`, then paint a native `outline: 1px dashed var(--hds-palette-focus-minimal)` on the adjacent `<label>`. Pattern lives directly in `components/_form.scss` (no shared mixin).
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# HDS Core Architecture
+﻿# HDS Core Architecture
 
 Technical decisions by maintainers and conventions for contributors.
 
@@ -214,38 +214,28 @@ Always use `../assets/img/` in component styles. Configured in `_hds-uswds-theme
 
 ## Focus Ring Architecture
 
-HDS components use three distinct focus mechanisms:
+HDS components use a hybrid approach to focus rings to perfectly match the Figma spec (1px stroke, 2,3 dash array) while avoiding layout shifts caused by USWDS structural quirks.
 
-| System | Mechanism | Components | Token Strategy |
-| --- | --- | --- | --- |
-| **Dashed outline ring** | Outline or border around component, contrasts against palette background | Link, Buttons, Icon buttons, Primary arrow, Accordion, Breadcrumb, Pagination, Checkbox/Radio outer box | `--hds-palette-focus-*` tokens + `hds-focus-ring()` mixin |
-| **Solid blue element highlight** | Blue border on the form element itself | Text input, Select, Checkbox inner ring, Radio inner ring | `--hds-palette-btn-secondary-bg` — no change needed |
-| **Surface-inverse ring** | Ring color is inverse of component's own fill, not palette background | Table body cells, Table header cells | Per-component logic in `_table.scss` |
+### Two Focus Systems
 
-### Dashed outline ring system
+1. **Hybrid Dashed Ring:** Used by most interactive components (Links, Buttons, Accordions, Forms, etc.). Driven by `--hds-palette-focus-*` tokens.
+2. **Surface-inverse Ring:** Used strictly for Table cells. The ring color is calculated as the inverse of the component's own fill (see `_table.scss`).
 
-All selectors use `:focus-visible` (keyboard only, not mouse click). A suppression rule in `base/_focus.scss` prevents USWDS `:focus` styles from bleeding through on mouse interaction.
+### Application Methods (Dashed Ring)
 
-**Tokens:** Four semantic focus tokens in `base/_palettes.scss`, matching Figma's five focus patterns (the fifth — Interactive — is fixed/exempt):
+All selectors use `:focus-visible` (keyboard only). A suppression rule in `base/_focus.scss` prevents USWDS `:focus` styles from bleeding through on mouse interaction.
 
-| Token | Figma Pattern | Light Value | Dark Value | Components |
-| --- | --- | --- | --- | --- |
-| `--hds-palette-focus` | A (default) | C60 | C30 | Link, Primary arrow, Utility icon btn, Accordion (via global), Pagination prev/next, Breadcrumb, In-Page Navigation |
-| `--hds-palette-focus-bold` | B (bold) | C30 | C30 | CTA/Secondary/Outline text buttons, CTA/Secondary/Outline/Social icon btns |
-| `--hds-palette-focus-subtle` | E (subtle) | C60 | C40 | Pagination page numbers, Pagination simplified btn |
-| `--hds-palette-focus-minimal` | D (minimal) | C30 | C80 | Checkbox/Radio outer box |
+To prevent layout shifts, the dashed system uses four application methods depending on the component's layout constraints:
 
-Midtone and blue palettes override specific tokens where the scheme default would be invisible. See `base/_palettes.scss` code comments for per-palette values.
+1. **Blocks, Buttons, and Utility Circles:** Uses `@include hds-focus-ring(<shape>, <token>)`. Creates an absolute pseudo-element and applies a dynamically generated, data-URI SVG mask.
+2. **Inline Text (Links, Unstyled Buttons):** Uses `@include hds-focus-ring-inline()`. Relies on native CSS `outline: 1px dashed` and `box-decoration-break: clone`.
+3. **Form Elements (Checkboxes & Radios):** Applies `display: inline-flex` to the label wrapper, locks the hidden input with `position: absolute`, and applies a native outline to the adjacent `<label>` sibling.
+4. **Accordions:** Applies `position: relative` and an empty `::before` pseudo-element to the default button state to prevent the `space-between` flexbox layout from recalculating when the focus ring mixin injects its mask.
 
-**Width tokens:** `$hds-focus-widths` map in `_hds-tokens.scss` with `'thin'` (1px) and `'thick'` (2px) entries. Thin is the default; thick is used by text buttons, primary arrow, and breadcrumb.
+### Tokens and Globals
 
-**Mixin:** `hds-focus-ring($color, $width, $method, $offset)` in `_hds-mixins.scss`. Supports `'outline'` (default — emits `outline` + `outline-offset`) and `'border'` (emits `border-color` + `border-style` + `outline: none`) methods. Border method is used by pagination page numbers and simplified button, which pre-reserve a transparent border for focus.
-
-**Global rule:** `base/_focus.scss` applies `hds-focus-ring()` with defaults (Pattern A, thin, outline, 2px offset) to all focusable elements. Components override as needed.
-
-**Interactive icon button** is exempt — uses a fixed focus ring (1px dashed Carbon 40, 1px offset) that does not adapt to palettes. Designed for use over images, video, and 3D content.
-
-See DESIGN.md for design rationale behind the focus patterns and Figma deviations.
+- **Semantic Tokens:** The four adaptive focus treatments are defined as semantic tokens in `base/_palettes.scss`. This file also contains the explicit logic for swapping midtone and blue values to prevent contrast failures.
+- **Global Fallback:** `base/_focus.scss` applies the `hds-focus-ring()` mixin with baseline defaults (Default treatment, rect shape) to all focusable elements. Components then override this global rule as needed.
 
 ## Icon Architecture
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-﻿# HDS Core Architecture
+# HDS Core Architecture
 
 Technical decisions by maintainers and conventions for contributors.
 
@@ -214,28 +214,50 @@ Always use `../assets/img/` in component styles. Configured in `_hds-uswds-theme
 
 ## Focus Ring Architecture
 
-HDS components use a hybrid approach to focus rings to perfectly match the Figma spec (1px stroke, 2,3 dash array) while avoiding layout shifts caused by USWDS structural quirks.
+HDS focus rings target a 1px dashed Figma spec (`2,3` dasharray) while sidestepping USWDS structural quirks that cause layout shifts. All selectors use `:focus-visible` (keyboard only). A suppression rule in `base/_focus.scss` clears USWDS's `:focus` styles on mouse click so they don't bleed through.
 
-### Two Focus Systems
+### Three Focus Systems
 
-1. **Hybrid Dashed Ring:** Used by most interactive components (Links, Buttons, Accordions, Forms, etc.). Driven by `--hds-palette-focus-*` tokens.
-2. **Surface-inverse Ring:** Used strictly for Table cells. The ring color is calculated as the inverse of the component's own fill (see `_table.scss`).
+1. **Hybrid Dashed Ring** — most interactive components (links, buttons, accordion, pagination, in-page nav, breadcrumb, checkbox, radio). Palette-aware via `--hds-palette-focus-*` tokens. Four adaptive treatments (`default`, `bold`, `subtle`, `minimal`) plus one fixed exemption. See DESIGN.md for treatment rationale and Figma deviations.
+2. **Solid Blue Element Highlight** — text inputs, textareas, selects. Border thickens to 2px in `--hds-palette-btn-secondary-bg`. Intentionally separate from the dashed system. See `components/_form.scss` and Issue #20.
+3. **Surface-inverse Ring** — table cells. Ring color is calculated as the inverse of the cell fill. **Not yet implemented** — currently inherits the global default ring. Tracked as Phase 2 work in DESIGN.md.
+
+### Mixins
+
+All defined in `_hds-mixins.scss` (public Sass surface).
+
+| Mixin                   | Signature                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `hds-focus-ring`        | `($color: 'default', $shape: 'rect', $pseudo: 'after', $circle-size-px: 24)` |
+| `hds-focus-ring-size`   | `($circle-size-px, $pseudo: 'after')`                                        |
+| `hds-focus-ring-inline` | `($color: 'default')`                                                        |
+
+`hds-focus-ring` parameters:
+
+- **`$color`** — `'default'`, `'bold'`, `'subtle'`, or `'minimal'`. Resolves to the matching `--hds-palette-focus-*` custom property with a light-scheme fallback for non-palette contexts.
+- **`$shape`** — `'rect'` (inherits the host's `border-radius`) or `'circle'`.
+- **`$pseudo`** — `'after'` (default) or `'before'`. Use `'before'` when the host already uses `::after` for another purpose. Current consumers: accordion chevron, in-page nav active bar, pagination current-page bar, primary arrow button.
+- **`$circle-size-px`** — host size in pixels. Only used when `$shape: 'circle'`. The mask SVG is generated at compile time to match exactly, eliminating `calc()`, percentage, and transform-based rounding bugs.
+
+`hds-focus-ring-size` overrides ring geometry on icon button size modifiers (`--xs`, `--lg`, etc.) without re-declaring the full mixin.
 
 ### Application Methods (Dashed Ring)
 
-All selectors use `:focus-visible` (keyboard only). A suppression rule in `base/_focus.scss` prevents USWDS `:focus` styles from bleeding through on mouse interaction.
+The mixin you call depends on the host element's layout:
 
-To prevent layout shifts, the dashed system uses four application methods depending on the component's layout constraints:
+1. **Block elements via SVG mask** — `hds-focus-ring()` on the host. Sets `position: relative`, kills the native outline, paints the ring through an absolute `::after` (or `::before`) pseudo-element with a `mask-image` data-URI SVG. The `2,3` dash pattern is baked into the SVG because native CSS `dashed` produces a different rhythm at 1px. Used by `.usa-button`, icon button circles, accordion headings, pagination links, in-page nav links, primary arrow button.
+2. **Inline text via native outline** — `hds-focus-ring-inline()` on the host. Native `outline: 1px dashed` plus `box-decoration-break: clone` so the ring wraps cleanly across line breaks. Used by `.usa-link`, `.usa-button--unstyled`, `.usa-breadcrumb__link`.
+3. **Form controls via sibling outline** — checkbox and radio labels apply `display: inline-flex`, lock the hidden input with `position: absolute`, then paint a native `outline: 1px dashed var(--hds-palette-focus-minimal)` on the adjacent `<label>`. Pattern lives directly in `components/_form.scss` (no shared mixin).
 
-1. **Blocks, Buttons, and Utility Circles:** Uses `@include hds-focus-ring(<shape>, <token>)`. Creates an absolute pseudo-element and applies a dynamically generated, data-URI SVG mask.
-2. **Inline Text (Links, Unstyled Buttons):** Uses `@include hds-focus-ring-inline()`. Relies on native CSS `outline: 1px dashed` and `box-decoration-break: clone`.
-3. **Form Elements (Checkboxes & Radios):** Applies `display: inline-flex` to the label wrapper, locks the hidden input with `position: absolute`, and applies a native outline to the adjacent `<label>` sibling.
-4. **Accordions:** Applies `position: relative` and an empty `::before` pseudo-element to the default button state to prevent the `space-between` flexbox layout from recalculating when the focus ring mixin injects its mask.
+### Fixed Exemption
 
-### Tokens and Globals
+`.hds-btn-icon--interactive` opts out of the palette system with a hardcoded `outline: 1px dashed $hds-color-carbon-40`. These buttons live over images, video, and 3D content where palette backgrounds don't apply; a fixed mid-contrast ring ensures consistent visibility on dynamic surfaces.
 
-- **Semantic Tokens:** The four adaptive focus treatments are defined as semantic tokens in `base/_palettes.scss`. This file also contains the explicit logic for swapping midtone and blue values to prevent contrast failures.
-- **Global Fallback:** `base/_focus.scss` applies the `hds-focus-ring()` mixin with baseline defaults (Default treatment, rect shape) to all focusable elements. Components then override this global rule as needed.
+### Tokens and Global Fallback
+
+Semantic tokens (`--hds-palette-focus`, `-bold`, `-subtle`, `-minimal`) are defined in `base/_palettes.scss`. That file also contains the midtone-and-blue palette swap logic that prevents contrast failures (see DESIGN.md "Figma Deviations").
+
+`base/_focus.scss` applies `hds-focus-ring()` with default treatment and rect shape to all natively focusable elements (`button`, `input`, `select`, `textarea`, `[tabindex]`, `[contenteditable]`, `iframe`). Component selectors override this baseline. The baseline is what gives stock USWDS markup an HDS focus ring out of the box — see `stories/guides/USWDSDocumentation.stories.js` for the integration scenario this protects.
 
 ## Icon Architecture
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 Technical decisions by maintainers and conventions for contributors.
 
-Last updated: 2026-05-20
+Last updated: 2026-06-02
 
 ## Package Overview
 
@@ -246,12 +246,12 @@ All defined in `_hds-mixins.scss` (public Sass surface).
 The mixin you call depends on the host element's layout:
 
 1. **Block elements via SVG mask** — `hds-focus-ring()` on the host. Sets `position: relative`, kills the native outline, paints the ring through an absolute `::before` (or `::after`) pseudo-element with a `mask-image` data-URI SVG. The `2,3` dash pattern is baked into the SVG because native CSS `dashed` produces a different rhythm at 1px. Used by `.usa-button`, icon button circles, accordion headings, pagination links, in-page nav links, primary arrow button.
-2. **Inline text via native outline** — `hds-focus-ring-inline()` on the host. Native `outline: 1px dashed` plus `box-decoration-break: clone` so the ring wraps cleanly across line breaks. Used by `.usa-link`, `.usa-button--unstyled`, `.usa-breadcrumb__link`.
+2. **Inline text via repeating-linear-gradient** — `hds-focus-ring-inline()` on the host. Four `repeating-linear-gradient` layers paint the `2,3` dash spec on bottom, top, left, and right edges of the element's padding box. `background-image` on inline elements fragments naturally per line box — each wrapped line gets its own ring without `box-decoration-break`. The host must have always-on `padding: 0 4px` so left/right edges have space to render; `hds-link-appearance` provides this for links and unstyled buttons, breadcrumbs set it directly. Used by `.usa-link`, `.usa-button--unstyled`, `.usa-breadcrumb__link`.
 3. **Form controls via sibling outline** — checkbox and radio labels apply `display: inline-flex`, lock the hidden input with `position: absolute`, then paint a native `outline: 1px dashed var(--hds-palette-focus-minimal)` on the adjacent `<label>`. Pattern lives directly in `components/_form.scss` (no shared mixin).
 
 ### Fixed Exemption
 
-`.hds-btn-icon--interactive` opts out of the palette system with a hardcoded `outline: 1px dashed $hds-color-carbon-40`. These buttons live over images, video, and 3D content where palette backgrounds don't apply; a fixed mid-contrast ring ensures consistent visibility on dynamic surfaces.
+`.hds-btn-icon--interactive` uses `hds-focus-ring($shape: 'circle')` like all other icon button roles, but overrides `::before { background-color }` with a hardcoded `$hds-color-carbon-40`. These buttons live over images, video, and 3D content where palette containers don't apply; a fixed mid-contrast ring ensures consistent visibility on dynamic surfaces.
 
 ### Tokens and Global Fallback
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,20 @@ Open an [Issue](https://github.com/nasa/hds-core/issues). Include what you expec
 
 Start a [Discussion](https://github.com/nasa/hds-core/discussions). This is the right place for open-ended questions, design proposals, integration challenges, and "has anyone tried..." conversations.
 
+### Edit documentation
+
+The Storybook documentation site has an **Edit this page on GitHub ↗** link at the bottom of every page. Clicking it opens the file in GitHub's browser editor — no local development environment needed.
+
+**Safe to edit:** paragraph text, headings, list items, and table cell content.
+
+**Leave alone:** any line starting with `import`, the `<Meta title="..." />` line near the top of each file, and anything inside `< >` angle brackets. These are code, not prose — editing them can break the page silently.
+
+To submit your changes:
+
+1. Make your edits in the GitHub browser editor.
+2. Click **Commit changes…**, write a short description, and choose **Create a new branch** using the `docs/` prefix (e.g. `docs/fix-button-copy`).
+3. Open a pull request to `main`. A formatting bot runs automatically and may commit small whitespace fixes on your behalf. A maintainer will review and merge.
+
 ### Submit a code change
 
 Open a pull request. See the sections below for setup instructions, conventions, and what we look for in review.
@@ -178,10 +192,14 @@ When filing, note in the issue title or description that the root cause is upstr
 
 ## Storybook documentation
 
-Storybook is the primary reference for adopters. Review [DOCUMENTATION.md](DOCUMENTATION.md) for guidelines on writing documentation (plain language, palette awareness, avoiding internal architecture terms). When changing or adding a component:
+Storybook is the primary reference for adopters. Review [DOCUMENTATION.md](DOCUMENTATION.md) for guidelines on writing documentation (plain language, palette awareness, avoiding internal architecture terms).
+
+For prose-only edits — rewording guidance, fixing typos, updating copy — see [Edit documentation](#edit-documentation) above. No development setup needed.
+
+When changing or adding a component:
 
 - Update or create the `.mdx` file for documentation and the `.stories.js` file for interactive examples in `stories/components/`.
-- A complete component requires both a **Guidance** tab (how and when to use, accessibility notes) and a **Playground** tab (interactive `.stories.js` embed).
+- A complete component requires a **Guidance** page (how and when to use, accessibility notes), key variants as standalone interactive stories (with exposed controls for users to change their content and settings), and an "All Variants" story (if more than one variant).
 
 ## Design proposals
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,7 +4,7 @@ Visual and UX decisions for the HDS creative director, designers, and design-min
 
 For implementation architecture, see ARCHITECTURE.md. For Storybook documentation conventions, see DOCUMENTATION.md. For implementation details (token values, contrast ratios, typography specs), see the SCSS source files — code comments are the single source of truth for "what values does this use."
 
-Last updated: 2026-04-26
+Last updated: 2026-06-02
 
 ## Class Naming Convention
 
@@ -145,19 +145,21 @@ Composite typography tokens are planned post-1.0, pending Style Dictionary compo
 
 ### Underline Style
 
-**Figma:** Dashed, 1px, "2, 3" dash pattern. **HDS Core:** `text-decoration-style: dashed`.
+**Figma:** Dashed, 1px, "2, 3" dash pattern. **HDS Core:** `repeating-linear-gradient`.
 
-Matches NASA.gov production styling: dashed underline, `.05em` thickness, `.25rem` offset. CSS `text-decoration` doesn't support custom dash patterns ("2, 3") but `dashed` at thin weights is visually close to the Figma intent and consistent with focus ring styles (also dashed) across the system.
+Matches NASA.gov production styling: dashed underline using a `repeating-linear-gradient` that produces the exact Figma `2,3` dash spec (2px dash, 3px gap). Uses `background-image` rather than `text-decoration` so the underline and focus ring share the same coordinate origin; the bottom edge does not shift when focus is applied.
+
+Always-on `padding: 0 4px` and `margin: 0 -4px` on the link element provide horizontal breathing room for the focus ring without affecting text layout.
 
 ### Hover Behavior
 
-Link text color stays constant. Only the underline changes from dashed to solid on hover.
+### Hover Behavior
+
+Link text color stays constant. Only the underline changes from dashed to solid on hover. Implemented by swapping the `repeating-linear-gradient` (dashed) for a plain `linear-gradient` (solid) at the same position and size.
 
 ### External Link Arrow
 
 HDS diagonal arrow (`arrow-line-diagonal.svg`) replaces USWDS launch icon. Arrow direction follows the HDS wayfinding rule: diagonal = leaving NASA. Appears automatically with no markup changes.
-
-**Known limitation:** CSS `text-decoration` cannot flow through `::after` pseudo-elements, creating a small underline gap before the arrow. Shared by USWDS, GOV.UK, and other government design systems.
 
 ### Unstyled Button
 
@@ -260,7 +262,7 @@ Figma's focus ring specifications contained a few inconsistencies and accessibil
 
 ### Interactive Icon Button Exemption
 
-Interactive icon buttons use a "Fixed" focus treatment (1px dashed Carbon 40, 1px offset) that does not adapt to palettes. Because these buttons are designed for use over images, video, and 3D content, a fixed, mid-contrast ring ensures consistent visibility against dynamic, unpredictable backgrounds where palette backgrounds don't apply.
+Interactive icon buttons use a "Fixed" focus treatment that does not adapt to palettes (always Carbon 40). Because these buttons are designed for use over images, video, and 3D content, a fixed, mid-contrast ring ensures consistent visibility against dynamic, unpredictable backgrounds where palette backgrounds don't apply.
 
 ## Table
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,4 +1,4 @@
-﻿# HDS Core Design Decisions
+# HDS Core Design Decisions
 
 Visual and UX decisions for the HDS creative director, designers, and design-minded developers. This document tracks where HDS Core intentionally differs from the HDS Core Proposal and HDS Figma spec, and flags items needing creative director review.
 
@@ -255,7 +255,7 @@ Figma's focus ring specifications contained a few inconsistencies and accessibil
 | --- | --- | --- | --- |
 | **Buttons (Bold)** | C30 on both light and dark | Ships as Figma specifies | Known WCAG 1.4.11 failure on light backgrounds; tracked in Issue #40 for CD review. |
 | **Checkbox/Radio (Minimal)** | C80 outer box on Carbon 90 | Ships as Figma specifies | Very low contrast, but matches Figma's intended dark-mode subtle design. |
-| **Midtone/Blue Palettes** | Only white + dark designed | Extended using closest scheme values | Midtone maps to the light scheme; Blue maps to the dark scheme. |
+| **Midtone/Blue Palettes** | Only white + dark designed | Extended using closest scheme values | Midtone reuses the light scheme via `_scheme-light`. Blue is a dark background but doesn't call `_scheme-dark`; it sets dark-scheme focus values explicitly. |
 | **Midtone/Blue (Minimal)** | Not designed | Midtone gets C80 (dark); Blue gets C30 (light) | Swapped for contrast. C30 on C20 is invisible (~1.1:1); C80 on Blue Shade is invisible. Swapping utilizes existing Figma colors. |
 
 ### Interactive Icon Button Exemption

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,4 +1,4 @@
-# HDS Core Design Decisions
+﻿# HDS Core Design Decisions
 
 Visual and UX decisions for the HDS creative director, designers, and design-minded developers. This document tracks where HDS Core intentionally differs from the HDS Core Proposal and HDS Figma spec, and flags items needing creative director review.
 
@@ -241,64 +241,26 @@ Text + CSS `::after` red circle with white arrow. The arrow is rendered via CSS 
 
 Default was moved from 32px (Figma XL) to 24px (Figma M) because 24px is the most frequently used size across Figma modules and matches the primary arrow button container. Uses px instead of em/rem — USWDS sets the root font-size to a non-16px value, causing em/rem to produce fractional pixel values. The 2xs size (12px) is below the WCAG 2.5.8 minimum touch target (24px) — desktop-only.
 
-## Focus Ring
+## Focus Rings
 
-### Three Focus Systems
+HDS components use a 1px dashed stroke for focus rings, strictly adhering to Figma's specifications across five distinct treatments: Default, Bold, Subtle, Minimal, and Fixed.
 
-HDS components use three distinct focus mechanisms. The dashed outline ring system is the only one addressed by the focus token infrastructure. See ARCHITECTURE.md for implementation details (tokens, mixin, file locations).
+See `ARCHITECTURE.md` for technical implementation details.
 
-| System | Mechanism | Components |
-| --- | --- | --- |
-| **Dashed outline ring** | Outline or border around component, contrasts against palette background | Link, Buttons, Icon buttons, Primary arrow, Accordion, Breadcrumb, Pagination, Checkbox/Radio outer box |
-| **Solid blue element highlight** | Blue border on the form element itself | Text input, Select, Checkbox inner ring, Radio inner ring |
-| **Surface-inverse ring** | Ring color is inverse of component's own fill | Table body cells, Table header cells |
+### Figma Deviations & Resolutions
 
-### Five Figma Focus Treatments
+Figma's focus ring specifications contained a few inconsistencies and accessibility gaps across palettes. HDS Core resolves these while maintaining the original design intent:
 
-Figma specifies five distinct treatments for the dashed outline ring system. Four are palette-aware via semantic tokens. One is exempt.
-
-| Treatment | Light Value | Dark Value | Components | Token |
-| --- | --- | --- | --- | --- |
-| **Default** | C60 | C30 | Link, Primary arrow, Utility icon btn, Accordion (global), Pagination prev/next, Breadcrumb | `--hds-palette-focus` |
-| **Bold** | C30 | C30 | CTA/Secondary/Outline text buttons, CTA/Secondary/Outline/Social icon btns | `--hds-palette-focus-bold` |
-| **Subtle** | C60 | C40 | Pagination page numbers, Pagination simplified btn | `--hds-palette-focus-subtle` |
-| **Minimal** | C30 | C80 | Checkbox/Radio outer box | `--hds-palette-focus-minimal` |
-| **Fixed** | C40 | C40 | Interactive icon button | None — exempt |
-
-### Figma Inconsistencies Resolved
-
-Figma's focus ring spec was not consistent across components. The standardization resolved these:
-
-| Issue | What Figma showed | What HDS Core does | Why |
+| Treatment/Component | What Figma showed | What HDS Core does | Rationale |
 | --- | --- | --- | --- |
-| **Buttons use C30 on light** | C30 on both light and dark (Pattern B) | Ships as Figma specifies | Known WCAG 1.4.11 failure — tracked in Issue #40 for CD review |
-| **Checkbox/Radio C80 on dark** | C80 outer box on Carbon 90 | Ships as Figma specifies | Very hard to see — flagged but matches Figma intent |
-| **No midtone/blue designs** | Only white + dark designed | Extended using closest scheme values | Midtone uses light scheme; blue uses dark scheme |
-| **Midtone/blue minimal swap** | Not designed | Midtone gets C80 (dark value), blue gets C30 (light value) | C30 on C20 is ~1.1:1 (invisible); C80 on Blue Shade is invisible. Swapped values use existing Figma colors without inventing new ones |
-
-### Style and Width
-
-All dashed outline focus rings use `dashed` style (not `dotted` — 1px dashed is visually indistinguishable from dotted at browser rendering level). Two widths per Figma:
-
-| Width     | Value | Components                                                            |
-| --------- | ----- | --------------------------------------------------------------------- |
-| **Thin**  | 1px   | Link, Icon buttons, Checkbox/Radio outer, Pagination, Global baseline |
-| **Thick** | 2px   | Text buttons (CTA/Secondary/Outline), Primary arrow, Breadcrumb       |
+| **Buttons (Bold)** | C30 on both light and dark | Ships as Figma specifies | Known WCAG 1.4.11 failure on light backgrounds; tracked in Issue #40 for CD review. |
+| **Checkbox/Radio (Minimal)** | C80 outer box on Carbon 90 | Ships as Figma specifies | Very low contrast, but matches Figma's intended dark-mode subtle design. |
+| **Midtone/Blue Palettes** | Only white + dark designed | Extended using closest scheme values | Midtone maps to the light scheme; Blue maps to the dark scheme. |
+| **Midtone/Blue (Minimal)** | Not designed | Midtone gets C80 (dark); Blue gets C30 (light) | Swapped for contrast. C30 on C20 is invisible (~1.1:1); C80 on Blue Shade is invisible. Swapping utilizes existing Figma colors. |
 
 ### Interactive Icon Button Exemption
 
-Interactive icon buttons use a fixed focus ring (1px dashed Carbon 40, 1px offset) that does not adapt to palettes. They are designed for use over images, video, and 3D content where palette backgrounds don't apply. The fixed ring provides consistent visibility on dynamic backgrounds.
-
-### Bug Fixes
-
-The following bugs were fixed as part of the focus ring standardization:
-
-| Bug | Components | Fix |
-| --- | --- | --- |
-| `dotted` instead of `dashed` | Link, Primary arrow, Breadcrumb | Style corrected to `dashed` |
-| Unstyled button focus doesn't match Link | `.usa-button--unstyled` | Own `:focus-visible` rule: thin width, default color |
-| Wrong token used for focus | Link (`--hds-palette-link-arrow`), Primary arrow (`--hds-palette-link-text`), Checkbox/Radio (`--hds-palette-border`) | Dedicated focus tokens |
-| No per-role focus on icon buttons | All roles shared one rule | Split: Utility → default, CTA/Sec/Out/Social → bold |
+Interactive icon buttons use a "Fixed" focus treatment (1px dashed Carbon 40, 1px offset) that does not adapt to palettes. Because these buttons are designed for use over images, video, and 3D content, a fixed, mid-contrast ring ensures consistent visibility against dynamic, unpredictable backgrounds where palette backgrounds don't apply.
 
 ## Table
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12262,6 +12262,16 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3100,6 +3100,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3121,6 +3124,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3142,6 +3148,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3163,6 +3172,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3184,6 +3196,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3205,6 +3220,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3443,6 +3461,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3460,6 +3481,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3477,6 +3501,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3494,6 +3521,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3555,9 +3585,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
       "cpu": [
         "arm64"
       ],
@@ -3572,9 +3602,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
       "cpu": [
         "arm64"
       ],
@@ -3589,9 +3619,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
       "cpu": [
         "x64"
       ],
@@ -3606,9 +3636,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
       "cpu": [
         "x64"
       ],
@@ -3623,9 +3653,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
       "cpu": [
         "arm"
       ],
@@ -3640,13 +3670,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3657,13 +3690,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3674,13 +3710,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3691,13 +3730,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3708,13 +3750,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3725,13 +3770,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3742,9 +3790,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
       "cpu": [
         "arm64"
       ],
@@ -3759,9 +3807,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
       "cpu": [
         "wasm32"
       ],
@@ -3778,9 +3826,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
       "cpu": [
         "arm64"
       ],
@@ -3795,9 +3843,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
       "cpu": [
         "x64"
       ],
@@ -3812,9 +3860,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4130,9 +4178,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5066,9 +5114,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
-      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5230,9 +5278,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
       "dev": true,
       "funding": [
         {
@@ -6265,9 +6313,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.348",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.348.tgz",
-      "integrity": "sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q==",
+      "version": "1.5.355",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.355.tgz",
+      "integrity": "sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -7110,9 +7158,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8073,6 +8121,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8094,6 +8145,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8115,6 +8169,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8136,6 +8193,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8418,13 +8478,13 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
+        "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
@@ -9788,9 +9848,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11208,9 +11268,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11218,16 +11278,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-is": {
@@ -12169,14 +12229,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -12185,21 +12245,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/run-applescript": {
@@ -12301,6 +12361,7 @@
       "cpu": [
         "x64"
       ],
+      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12359,9 +12420,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -14308,16 +14369,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -14334,7 +14395,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -14808,9 +14869,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/public-api.snapshot.txt
+++ b/public-api.snapshot.txt
@@ -289,6 +289,8 @@ $hds-width-settings
 
 ## Sass Mixins (_hds-mixins.scss)
 hds-focus-ring
+hds-focus-ring-inline
+hds-focus-ring-size
 hds-link-appearance
 hds-link-hover
 hds-metadata-type

--- a/public-api.snapshot.txt
+++ b/public-api.snapshot.txt
@@ -421,6 +421,7 @@ hds-vertical-nav-links
 .usa-radio__input
 .usa-radio__input--tile
 .usa-radio__label
+.usa-radio__label-description
 .usa-section
 .usa-select
 .usa-sidenav

--- a/public-api.snapshot.txt
+++ b/public-api.snapshot.txt
@@ -351,9 +351,7 @@ hds-vertical-nav-links
 .usa-banner__button
 .usa-banner__header
 .usa-breadcrumb
-.usa-breadcrumb--wrap
 .usa-breadcrumb__link
-.usa-breadcrumb__list
 .usa-breadcrumb__list-item
 .usa-button
 .usa-button--arrow

--- a/public-api.snapshot.txt
+++ b/public-api.snapshot.txt
@@ -277,7 +277,6 @@ $hds-enable-auto-dark-mode
 $hds-enable-dataviz-tokens
 $hds-enable-experimental-palettes
 $hds-extended-palette
-$hds-focus-widths
 $hds-letterspacing
 $hds-line-heights
 $hds-radius-settings

--- a/public-api.snapshot.txt
+++ b/public-api.snapshot.txt
@@ -351,7 +351,9 @@ hds-vertical-nav-links
 .usa-banner__button
 .usa-banner__header
 .usa-breadcrumb
+.usa-breadcrumb--wrap
 .usa-breadcrumb__link
+.usa-breadcrumb__list
 .usa-breadcrumb__list-item
 .usa-button
 .usa-button--arrow

--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -5,17 +5,19 @@
 # Run automatically in CI when src/scss/** or tokens.json changes.
 # Run locally: bash scripts/check-bundle-size.sh (requires gzip + wc)
 #
-# Thresholds set from post-refactor measurements (May 2026, v0.7.2):
-#   hds.min.css:       43.3 KB measured -- 45 KB ceiling (hard fail)
-#   hds-uswds.min.css: 47.9 KB measured -- combined 95 KB ceiling (informational)
+# All limits use decimal KB (1 KB = 1,000 bytes), matching browser devtools.
+#
+# Thresholds set from post-refactor measurements (June 2026, v0.8.0):
+#   hds.min.css:       46.1 KB measured -- 48 KB ceiling (hard fail)
+#   hds-uswds.min.css: 47.9 KB measured -- combined 96 KB ceiling (informational)
 #
 # hds.min.css is the mandatory adopter load and the only enforced gate.
 # hds-uswds.min.css is an optional utilities addon for USWDS migration sites.
 
 set -euo pipefail
 
-HDS_MAX=46080        # 45 KB
-COMBINED_MAX=97280   # 95 KB
+HDS_MAX=48000        # 48 KB
+COMBINED_MAX=96000   # 96 KB
 
 if [ ! -f dist/css/hds.min.css ]; then
   echo "ERROR: dist/css/hds.min.css not found -- run npm run build first"
@@ -27,7 +29,7 @@ hds_gz=$(gzip -c dist/css/hds.min.css | wc -c)
 fail=0
 
 if [ "$hds_gz" -gt "$HDS_MAX" ]; then
-  echo "FAIL hds.min.css: ${hds_gz}B > ${HDS_MAX}B (limit: 45 KB gzipped)"
+  echo "FAIL hds.min.css: ${hds_gz}B > ${HDS_MAX}B (limit: 48 KB gzipped)"
   fail=1
 else
   echo "OK   hds.min.css: ${hds_gz}B (limit: ${HDS_MAX}B)"

--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -354,6 +354,7 @@ $_focus-ring-rect-svg: "data:image/svg+xml,%3Csvg width='100%25' height='100%25'
 @mixin hds-link-appearance {
   color: var(--hds-palette-link-text, #{$hds-color-carbon-90});
   text-decoration: none;
+  display: inline;
   padding: 0 4px;
   margin: 0 -4px;
   box-decoration-break: clone;

--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -7,12 +7,16 @@
 //
 // CONTENTS:
 //   Accessibility — visually-hidden
-//   Focus         — hds-focus-ring
+//   Focus         — hds-focus-ring, hds-focus-ring-size,
+//                   hds-focus-ring-inline
 //   Typography    — hds-overline-label, hds-metadata-type, intro-text
-//   Buttons       — structure, color, interactive states, round
+//   Buttons       — button-styles (bundles button-padding-border,
+//                   button-typography, and button-color),
+//                   button-interactive-states, button-round
 //   Utility       — hds-utility-circle (pagination, icon buttons)
-//   Links         — hds-link-appearance, hds-link-hover,
-//                   hds-nav-hover-underline
+//   Links         — hds-link-appearance, hds-link-hover
+//   Navigation    — hds-nav-hover-underline (breadcrumb, in-page nav,
+//                   side nav), hds-vertical-nav-links
 // ============================================================
 
 @use 'sass:map';
@@ -48,11 +52,22 @@
 //   'subtle'   — C60 light / C40 dark
 //   'minimal'  — C30 light / C80 dark
 //
-// Standard properties: 1px width, 1px offset, 2,3 dasharray.
-// SVG Masks defined in _custom-properties.scss.
+// Standard properties: 1px stroke, 2,3 dasharray.
+//
+// Three application methods — pick by host layout:
+//   hds-focus-ring()        — block/flex elements (buttons,
+//                             pagination, accordion). SVG mask
+//                             on ::before (default) or ::after.
+//   hds-focus-ring-size()   — overrides circle ring geometry
+//                             on icon button size modifiers.
+//   hds-focus-ring-inline() — inline text elements (links,
+//                             unstyled buttons, breadcrumbs).
+//                             Four-sided repeating-linear-gradient
+//                             ring; fragments per line box on
+//                             multiline elements.
 // ------------------------------------------------------------
 
-// Fallback values for use without palette wrappers.
+// Fallback values for contexts without a palette wrapper.
 // Each maps to the light-scheme value for that treatment.
 $_focus-fallbacks: (
   'default': $hds-color-carbon-60,
@@ -61,11 +76,16 @@ $_focus-fallbacks: (
   'minimal': $hds-color-carbon-30,
 );
 
-// Standard block-level elements (buttons, pagination)
-// Default $pseudo is 'before' so component-owned ::after icons
-// (chevrons, arrows, active bars) aren't clobbered by the global
-// focus rule in base/_focus.scss. Pass $pseudo: 'after' if the
-// component owns ::before instead.
+// Rect SVG mask — module-level constant (never varies).
+// overflow="visible" lets the outer half of the 1px stroke
+// paint outside the SVG viewport; the pseudo's inset: -2px
+// provides that space so no edge is clipped.
+$_focus-ring-rect-svg: "data:image/svg+xml,%3Csvg width='100%25' height='100%25' overflow='visible' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='100%25' height='100%25' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2%2C3' stroke-dashoffset='1' stroke-linecap='butt'/%3E%3C/svg%3E";
+
+// Block/flex elements (buttons, accordion, pagination, primary arrow).
+// $pseudo defaults to 'before' because component-owned trailing icons
+// (chevrons, arrows, active bars) conventionally live on ::after.
+// Pass $pseudo: 'after' only when the host already uses ::before.
 @mixin hds-focus-ring($color: 'default', $shape: 'rect', $pseudo: 'before', $circle-size-px: 24) {
   $suffix: '';
 
@@ -77,7 +97,7 @@ $_focus-fallbacks: (
   $fallback: map.get($_focus-fallbacks, $color);
 
   position: relative;
-  outline: none; // Override native focus
+  outline: none;
 
   &::#{$pseudo} {
     content: '';
@@ -87,8 +107,6 @@ $_focus-fallbacks: (
     z-index: 1;
 
     @if $shape == 'circle' {
-      // Generate hardcoded pixel values at compile time based on button size.
-      // This eliminates all calc(), percentages, inset, and transform bugs.
       $container-size: $circle-size-px + 6;
       $center: $container-size * 0.5;
       $radius: $center - 1.5;
@@ -99,44 +117,40 @@ $_focus-fallbacks: (
       height: #{$container-size}px;
       margin-top: -#{$center}px;
       margin-left: -#{$center}px;
-
-      $svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$container-size}' height='#{$container-size}'%3E%3Ccircle cx='#{$center}' cy='#{$center}' r='#{$radius}' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' stroke-linecap='butt'/%3E%3C/svg%3E";
-
-      mask-image: url($svg);
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$container-size}' height='#{$container-size}' overflow='visible'%3E%3Ccircle cx='#{$center}' cy='#{$center}' r='#{$radius}' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' stroke-linecap='butt'/%3E%3C/svg%3E");
       mask-size: 100% 100%;
     } @else {
       inset: -2px;
-
-      $svg-rect: "data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2%2c3' stroke-dashoffset='1' stroke-linecap='butt'/%3e%3c/svg%3e";
-
-      mask-image: url($svg-rect);
       border-radius: inherit;
+      mask-image: url($_focus-ring-rect-svg);
       mask-size: 100% 100%;
     }
   }
 }
 
-// ------------------------------------------------------------
-// Focus Ring Size Override (For circle modifiers)
-// ------------------------------------------------------------
+// Overrides circle ring geometry for icon button size modifiers
+// (--xs, --sm, --lg, etc.) without re-declaring the full mixin.
 @mixin hds-focus-ring-size($circle-size-px, $pseudo: 'before') {
-  &::#{$pseudo} {
-    $container-size: $circle-size-px + 6;
-    $center: $container-size * 0.5;
-    $radius: $center - 1.5;
+  $container-size: $circle-size-px + 6;
+  $center: $container-size * 0.5;
+  $radius: $center - 1.5;
 
+  &::#{$pseudo} {
     width: #{$container-size}px;
     height: #{$container-size}px;
     margin-top: -#{$center}px;
     margin-left: -#{$center}px;
-
-    $svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$container-size}' height='#{$container-size}'%3E%3Ccircle cx='#{$center}' cy='#{$center}' r='#{$radius}' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' stroke-linecap='butt'/%3E%3C/svg%3E";
-
-    mask-image: url($svg);
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$container-size}' height='#{$container-size}' overflow='visible'%3E%3Ccircle cx='#{$center}' cy='#{$center}' r='#{$radius}' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' stroke-linecap='butt'/%3E%3C/svg%3E");
   }
 }
 
-// Inline multi-line elements (links)
+// Inline text elements (links, unstyled buttons, breadcrumbs).
+// Four repeating-linear-gradient layers draw the 2,3 dash spec
+// on all four edges. background-image on inline elements fragments
+// naturally per line box — each wrapped line gets its own ring.
+// The host must have padding: 0 4px (always-on) so the left/right
+// edges have space to render; hds-link-appearance provides this
+// for links and unstyled buttons. Breadcrumb sets it directly.
 @mixin hds-focus-ring-inline($color: 'default') {
   $suffix: '';
 
@@ -147,11 +161,28 @@ $_focus-fallbacks: (
   $prop: --hds-palette-focus#{$suffix};
   $fallback: map.get($_focus-fallbacks, $color);
 
-  outline: 1px dashed var(#{$prop}, #{$fallback});
-  outline-offset: 1px;
-  box-decoration-break: clone;
-  // stylelint-disable-next-line property-no-vendor-prefix
-  -webkit-box-decoration-break: clone;
+  // Local custom property avoids repeating var() across gradient layers.
+  --hds-ring: var(#{$prop}, #{$fallback});
+
+  outline: none;
+
+  // Order: bottom, top, left, right
+  background-image:
+    repeating-linear-gradient(to right, var(--hds-ring) 0, var(--hds-ring) 2px, transparent 2px, transparent 5px),
+    repeating-linear-gradient(to right, var(--hds-ring) 0, var(--hds-ring) 2px, transparent 2px, transparent 5px),
+    repeating-linear-gradient(to bottom, var(--hds-ring) 0, var(--hds-ring) 2px, transparent 2px, transparent 5px),
+    repeating-linear-gradient(to bottom, var(--hds-ring) 0, var(--hds-ring) 2px, transparent 2px, transparent 5px);
+  background-size:
+    100% 1px,
+    100% 1px,
+    1px 100%,
+    1px 100%;
+  background-position:
+    0 100%,
+    0 0,
+    0 0,
+    100% 0;
+  background-repeat: no-repeat;
 }
 
 // ------------------------------------------------------------
@@ -193,7 +224,7 @@ $_focus-fallbacks: (
 }
 
 // ------------------------------------------------------------
-// Button Structure
+// Buttons
 // ------------------------------------------------------------
 
 @mixin button-padding-border {
@@ -211,10 +242,6 @@ $_focus-fallbacks: (
   line-height: 1.2; // Proposal 120%; USWDS token 3 (1.35) too coarse
   text-decoration-line: none;
 }
-
-// ------------------------------------------------------------
-// Button Colors (palette-aware)
-// ------------------------------------------------------------
 
 @mixin button-color {
   background-color: var(--hds-palette-btn-primary-bg, #{$hds-color-nasa-red});
@@ -292,23 +319,50 @@ $_focus-fallbacks: (
 // ------------------------------------------------------------
 // Link appearance
 // ------------------------------------------------------------
-// Shared visual treatment for elements that look like text
-// links: .usa-link and .usa-button--unstyled.
-// Palette-aware with light-palette fallbacks.
+// Dashed underline via repeating-linear-gradient rather than
+// text-decoration, matching the Figma 2,3 dash spec exactly.
+// Uses background-image so it fragments per line box on
+// multiline inline elements (no box-decoration-break needed
+// for background — inline elements fragment backgrounds
+// natively with clone).
+//
+// Horizontal padding (4px) per Figma focus ring spec — always
+// present so no layout shift occurs on focus.
 // ------------------------------------------------------------
 
 @mixin hds-link-appearance {
   color: var(--hds-palette-link-text, #{$hds-color-carbon-90});
-  text-decoration-color: var(--hds-palette-link-underline, #{$hds-color-carbon-60});
-  text-decoration-line: underline;
-  text-decoration-style: dashed;
-  text-decoration-thickness: 0.05em;
-  text-underline-offset: 0.25rem;
+  text-decoration: none;
+  padding: 0 4px;
+  margin: 0 -4px;
+  box-decoration-break: clone;
+  // stylelint-disable-next-line property-no-vendor-prefix
+  -webkit-box-decoration-break: clone;
+
+  // Dashed underline — content width only (excludes 4px padding each side)
+  background-image: repeating-linear-gradient(
+    to right,
+    var(--hds-palette-link-underline, #{$hds-color-carbon-60}) 0,
+    var(--hds-palette-link-underline, #{$hds-color-carbon-60}) 2px,
+    transparent 2px,
+    transparent 5px
+  );
+  background-size: calc(100% - 8px) 1px;
+  background-position: center 100%;
+  background-repeat: no-repeat;
 }
 
 @mixin hds-link-hover {
   color: var(--hds-palette-link-text, #{$hds-color-carbon-90});
-  text-decoration-style: solid;
+
+  // Solid underline — same content-width constraint
+  background-image: linear-gradient(
+    to right,
+    var(--hds-palette-link-underline, #{$hds-color-carbon-60}),
+    var(--hds-palette-link-underline, #{$hds-color-carbon-60})
+  );
+  background-size: calc(100% - 8px) 1px;
+  background-position: center 100%;
 }
 
 // ------------------------------------------------------------

--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -62,7 +62,7 @@ $_focus-fallbacks: (
 );
 
 // Standard block-level elements (buttons, pagination)
-@mixin hds-focus-ring($color: 'default', $shape: 'rect', $pseudo: 'after') {
+@mixin hds-focus-ring($color: 'default', $shape: 'rect', $pseudo: 'after', $circle-size-px: 24) {
   $suffix: '';
 
   @if $color != 'default' {
@@ -78,67 +78,59 @@ $_focus-fallbacks: (
   &::#{$pseudo} {
     content: '';
     position: absolute;
-    inset: -1px;
     pointer-events: none;
     background-color: var(#{$prop}, #{$fallback});
+    z-index: 1;
 
     @if $shape == 'circle' {
-      mask-image: var(--hds-focus-mask-circle);
-      -webkit-mask-image: var(--hds-focus-mask-circle);
-      border-radius: 50%;
-    } @else {
-      mask-image: var(--hds-focus-mask-rect);
-      -webkit-mask-image: var(--hds-focus-mask-rect);
-      border-radius: inherit;
-    }
+      // Generate hardcoded pixel values at compile time based on button size.
+      // This eliminates all calc(), percentages, inset, and transform bugs.
+      $container-size: $circle-size-px + 6;
+      $center: $container-size * 0.5;
+      $radius: $center - 1.5;
 
-    mask-size: 100% 100%;
-    -webkit-mask-size: 100% 100%;
-    z-index: 1;
+      top: 50%;
+      left: 50%;
+      width: #{$container-size}px;
+      height: #{$container-size}px;
+      margin-top: -#{$center}px;
+      margin-left: -#{$center}px;
+
+      $svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$container-size}' height='#{$container-size}'%3E%3Ccircle cx='#{$center}' cy='#{$center}' r='#{$radius}' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' stroke-linecap='butt'/%3E%3C/svg%3E";
+      mask-image: url($svg);
+      -webkit-mask-image: url($svg);
+      mask-size: 100% 100%;
+      -webkit-mask-size: 100% 100%;
+
+    } @else {
+      inset: -2px;
+      $svg-rect: "data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2%2c3' stroke-dashoffset='1' stroke-linecap='butt'/%3e%3c/svg%3e";
+      mask-image: url($svg-rect);
+      -webkit-mask-image: url($svg-rect);
+      border-radius: inherit;
+      mask-size: 100% 100%;
+      -webkit-mask-size: 100% 100%;
+    }
   }
 }
 
-// Input wrappers (checkboxes, radios)
-@mixin hds-focus-ring-wrapped($color: 'minimal', $shape: 'rect') {
-  $suffix: '';
-  @if $color != 'default' {
-    $suffix: '-#{$color}';
-  }
-  $prop: --hds-palette-focus#{$suffix};
-  $fallback: map.get($_focus-fallbacks, $color);
+// ------------------------------------------------------------
+// Focus Ring Size Override (For circle modifiers)
+// ------------------------------------------------------------
+@mixin hds-focus-ring-size($circle-size-px, $pseudo: 'after') {
+  &::#{$pseudo} {
+    $container-size: $circle-size-px + 6;
+    $center: $container-size * 0.5;
+    $radius: $center - 1.5;
 
-  &::after {
-    content: '';
-    position: absolute;
-    pointer-events: none;
-    z-index: 1;
+    width: #{$container-size}px;
+    height: #{$container-size}px;
+    margin-top: -#{$center}px;
+    margin-left: -#{$center}px;
 
-    // USWDS checkbox size is 24px (1.5rem). Ring needs to be 1px offset around it.
-    // 24px + 1px left + 1px right = 26px ring size.
-    width: 26px;
-    height: 26px;
-
-    // Match ::before positioning minus 1px offset
-    // Checkbox has left padding, ::before is at left: 0
-    left: -1px;
-
-    // Center vertically exactly matching USWDS math minus offset
-    margin-top: calc(((line-height(body, 3) * size(body, md) - 1.5rem) / 2) - 1px);
-
-    background-color: var(#{$prop}, #{$fallback});
-
-    @if $shape == 'circle' {
-      mask-image: var(--hds-focus-mask-circle);
-      -webkit-mask-image: var(--hds-focus-mask-circle);
-      border-radius: 50%;
-    } @else {
-      mask-image: var(--hds-focus-mask-rect);
-      -webkit-mask-image: var(--hds-focus-mask-rect);
-      border-radius: 0; // Ensures it's square
-    }
-
-    mask-size: 100% 100%;
-    -webkit-mask-size: 100% 100%;
+    $svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$container-size}' height='#{$container-size}'%3E%3Ccircle cx='#{$center}' cy='#{$center}' r='#{$radius}' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' stroke-linecap='butt'/%3E%3C/svg%3E";
+    mask-image: url($svg);
+    -webkit-mask-image: url($svg);
   }
 }
 
@@ -308,6 +300,7 @@ $_focus-fallbacks: (
   display: inline-flex;
   justify-content: center;
   padding: 0;
+  position: relative;
 }
 
 // ------------------------------------------------------------

--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -161,17 +161,38 @@ $_focus-ring-rect-svg: "data:image/svg+xml,%3Csvg width='100%25' height='100%25'
   $prop: --hds-palette-focus#{$suffix};
   $fallback: map.get($_focus-fallbacks, $color);
 
-  // Local custom property avoids repeating var() across gradient layers.
-  --hds-ring: var(#{$prop}, #{$fallback});
-
   outline: none;
 
   // Order: bottom, top, left, right
   background-image:
-    repeating-linear-gradient(to right, var(--hds-ring) 0, var(--hds-ring) 2px, transparent 2px, transparent 5px),
-    repeating-linear-gradient(to right, var(--hds-ring) 0, var(--hds-ring) 2px, transparent 2px, transparent 5px),
-    repeating-linear-gradient(to bottom, var(--hds-ring) 0, var(--hds-ring) 2px, transparent 2px, transparent 5px),
-    repeating-linear-gradient(to bottom, var(--hds-ring) 0, var(--hds-ring) 2px, transparent 2px, transparent 5px);
+    repeating-linear-gradient(
+      to right,
+      var(#{$prop}, #{$fallback}) 0,
+      var(#{$prop}, #{$fallback}) 2px,
+      transparent 2px,
+      transparent 5px
+    ),
+    repeating-linear-gradient(
+      to right,
+      var(#{$prop}, #{$fallback}) 0,
+      var(#{$prop}, #{$fallback}) 2px,
+      transparent 2px,
+      transparent 5px
+    ),
+    repeating-linear-gradient(
+      to bottom,
+      var(#{$prop}, #{$fallback}) 0,
+      var(#{$prop}, #{$fallback}) 2px,
+      transparent 2px,
+      transparent 5px
+    ),
+    repeating-linear-gradient(
+      to bottom,
+      var(#{$prop}, #{$fallback}) 0,
+      var(#{$prop}, #{$fallback}) 2px,
+      transparent 2px,
+      transparent 5px
+    );
   background-size:
     100% 1px,
     100% 1px,

--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -48,18 +48,8 @@
 //   'subtle'   — C60 light / C40 dark (Pattern E)
 //   'minimal'  — C30 light / C80 dark (Pattern D)
 //
-// Two width tokens from $hds-focus-widths:
-//   'thin'  (1px) — Link, Icon buttons, Global baseline
-//   'thick' (2px) — Text buttons, Primary arrow, Breadcrumb
-//
-// Two methods:
-//   'outline' — outline + outline-offset (default)
-//   'border'  — border-color + border-style + outline:none
-//               (for components that pre-reserve a transparent
-//               border, e.g. pagination page numbers)
-//
-// Interactive icon button is exempt — uses fixed colors for
-// high contrast on dynamic backgrounds. Does not use this mixin.
+// Standard properties: 1px width, 1px offset, 2,3 dasharray.
+// SVG Masks defined in _custom-properties.scss.
 // ------------------------------------------------------------
 
 // Fallback values for use without palette wrappers.
@@ -71,7 +61,8 @@ $_focus-fallbacks: (
   'minimal': $hds-color-carbon-30,
 );
 
-@mixin hds-focus-ring($color: 'default', $width: 'thin', $method: 'outline', $offset: 2px) {
+// Standard block-level elements (buttons, pagination)
+@mixin hds-focus-ring($color: 'default', $shape: 'rect', $pseudo: 'after') {
   $suffix: '';
 
   @if $color != 'default' {
@@ -80,16 +71,90 @@ $_focus-fallbacks: (
 
   $prop: --hds-palette-focus#{$suffix};
   $fallback: map.get($_focus-fallbacks, $color);
-  $resolved-width: map.get($hds-focus-widths, $width);
 
-  @if $method == 'outline' {
-    outline: #{$resolved-width} dashed var(#{$prop}, #{$fallback});
-    outline-offset: $offset;
-  } @else if $method == 'border' {
-    border-color: var(#{$prop}, #{$fallback});
-    border-style: dashed;
-    outline: none;
+  position: relative;
+  outline: none; // Override native focus
+
+  &::#{$pseudo} {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    pointer-events: none;
+    background-color: var(#{$prop}, #{$fallback});
+
+    @if $shape == 'circle' {
+      mask-image: var(--hds-focus-mask-circle);
+      -webkit-mask-image: var(--hds-focus-mask-circle);
+      border-radius: 50%;
+    } @else {
+      mask-image: var(--hds-focus-mask-rect);
+      -webkit-mask-image: var(--hds-focus-mask-rect);
+      border-radius: inherit;
+    }
+
+    mask-size: 100% 100%;
+    -webkit-mask-size: 100% 100%;
+    z-index: 1;
   }
+}
+
+// Input wrappers (checkboxes, radios)
+@mixin hds-focus-ring-wrapped($color: 'minimal', $shape: 'rect') {
+  $suffix: '';
+  @if $color != 'default' {
+    $suffix: '-#{$color}';
+  }
+  $prop: --hds-palette-focus#{$suffix};
+  $fallback: map.get($_focus-fallbacks, $color);
+
+  &::after {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    z-index: 1;
+
+    // USWDS checkbox size is 24px (1.5rem). Ring needs to be 1px offset around it.
+    // 24px + 1px left + 1px right = 26px ring size.
+    width: 26px;
+    height: 26px;
+
+    // Match ::before positioning minus 1px offset
+    // Checkbox has left padding, ::before is at left: 0
+    left: -1px;
+
+    // Center vertically exactly matching USWDS math minus offset
+    margin-top: calc(((line-height(body, 3) * size(body, md) - 1.5rem) / 2) - 1px);
+
+    background-color: var(#{$prop}, #{$fallback});
+
+    @if $shape == 'circle' {
+      mask-image: var(--hds-focus-mask-circle);
+      -webkit-mask-image: var(--hds-focus-mask-circle);
+      border-radius: 50%;
+    } @else {
+      mask-image: var(--hds-focus-mask-rect);
+      -webkit-mask-image: var(--hds-focus-mask-rect);
+      border-radius: 0; // Ensures it's square
+    }
+
+    mask-size: 100% 100%;
+    -webkit-mask-size: 100% 100%;
+  }
+}
+
+// Inline multi-line elements (links)
+@mixin hds-focus-ring-inline($color: 'default') {
+  $suffix: '';
+  @if $color != 'default' {
+    $suffix: '-#{$color}';
+  }
+  $prop: --hds-palette-focus#{$suffix};
+  $fallback: map.get($_focus-fallbacks, $color);
+
+  outline: 1px dashed var(#{$prop}, #{$fallback});
+  outline-offset: 1px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 // ------------------------------------------------------------
@@ -316,7 +381,7 @@ $_focus-fallbacks: (
   }
 
   &:focus-visible {
-    @include hds-focus-ring($width: 'thin');
+    @include hds-focus-ring($pseudo: 'before');
   }
 
   &:not(.usa-current) {

--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -9,7 +9,7 @@
 //   Accessibility — visually-hidden
 //   Focus         — hds-focus-ring
 //   Typography    — hds-overline-label, hds-metadata-type, intro-text
-//   Buttons       — structure, color, hover, outline, round
+//   Buttons       — structure, color, interactive states, round
 //   Utility       — hds-utility-circle (pagination, icon buttons)
 //   Links         — hds-link-appearance, hds-link-hover,
 //                   hds-nav-hover-underline
@@ -43,10 +43,10 @@
 // base/_palettes.scss.
 //
 // Four color treatments matching Figma focus patterns:
-//   'default'  — C60 light / C30 dark (Pattern A)
-//   'bold'     — C30 universal (Pattern B)
-//   'subtle'   — C60 light / C40 dark (Pattern E)
-//   'minimal'  — C30 light / C80 dark (Pattern D)
+//   'default'  — C60 light / C30 dark
+//   'bold'     — C30 universal
+//   'subtle'   — C60 light / C40 dark
+//   'minimal'  — C30 light / C80 dark
 //
 // Standard properties: 1px width, 1px offset, 2,3 dasharray.
 // SVG Masks defined in _custom-properties.scss.
@@ -228,40 +228,21 @@ $_focus-fallbacks: (
   @include button-color;
 }
 
-@mixin button-hover {
-  &:hover {
-    filter: brightness(0.85);
+// Hover/active/focus states shared by .usa-button and the base
+// stock-button reset (base/_elements.scss). Defensive :not()
+// qualifiers prevent disabled buttons from picking up these states
+// regardless of source order.
+@mixin button-interactive-states {
+  &:hover:not(:disabled, [aria-disabled='true']),
+  &:active:not(:disabled, [aria-disabled='true']) {
+    background-color: $hds-color-nasa-red-shade;
     text-decoration-line: none;
   }
 
-  &:active {
-    filter: brightness(0.75);
-  }
+  &:focus-visible:not(:disabled, [aria-disabled='true']) {
+    @include hds-focus-ring($color: 'bold');
 
-  &:focus-visible {
-    outline: 2px solid var(--hds-palette-btn-secondary-bg, #{$hds-color-nasa-blue});
-    outline-offset: 2px;
     text-decoration-line: none;
-  }
-}
-
-@mixin button-outline {
-  @include button-padding-border;
-  @include button-typography;
-
-  background-color: transparent;
-  border-color: var(--hds-palette-btn-secondary-bg, #{$hds-color-nasa-blue});
-  color: var(--hds-palette-btn-secondary-bg, #{$hds-color-nasa-blue});
-
-  &:hover {
-    background-color: var(--hds-palette-btn-secondary-bg, #{$hds-color-nasa-blue});
-    color: var(--hds-palette-btn-filled-text, #{$hds-color-spacesuit-white});
-    text-decoration-line: none;
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--hds-palette-btn-secondary-bg, #{$hds-color-nasa-blue});
-    outline-offset: 2px;
   }
 }
 

--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -62,7 +62,11 @@ $_focus-fallbacks: (
 );
 
 // Standard block-level elements (buttons, pagination)
-@mixin hds-focus-ring($color: 'default', $shape: 'rect', $pseudo: 'after', $circle-size-px: 24) {
+// Default $pseudo is 'before' so component-owned ::after icons
+// (chevrons, arrows, active bars) aren't clobbered by the global
+// focus rule in base/_focus.scss. Pass $pseudo: 'after' if the
+// component owns ::before instead.
+@mixin hds-focus-ring($color: 'default', $shape: 'rect', $pseudo: 'before', $circle-size-px: 24) {
   $suffix: '';
 
   @if $color != 'default' {
@@ -115,7 +119,7 @@ $_focus-fallbacks: (
 // ------------------------------------------------------------
 // Focus Ring Size Override (For circle modifiers)
 // ------------------------------------------------------------
-@mixin hds-focus-ring-size($circle-size-px, $pseudo: 'after') {
+@mixin hds-focus-ring-size($circle-size-px, $pseudo: 'before') {
   &::#{$pseudo} {
     $container-size: $circle-size-px + 6;
     $center: $container-size * 0.5;
@@ -356,7 +360,7 @@ $_focus-fallbacks: (
   }
 
   &:focus-visible {
-    @include hds-focus-ring($pseudo: 'before');
+    @include hds-focus-ring;
   }
 
   &:not(.usa-current) {

--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -97,19 +97,17 @@ $_focus-fallbacks: (
       margin-left: -#{$center}px;
 
       $svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$container-size}' height='#{$container-size}'%3E%3Ccircle cx='#{$center}' cy='#{$center}' r='#{$radius}' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' stroke-linecap='butt'/%3E%3C/svg%3E";
-      mask-image: url($svg);
-      -webkit-mask-image: url($svg);
-      mask-size: 100% 100%;
-      -webkit-mask-size: 100% 100%;
 
+      mask-image: url($svg);
+      mask-size: 100% 100%;
     } @else {
       inset: -2px;
+
       $svg-rect: "data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2%2c3' stroke-dashoffset='1' stroke-linecap='butt'/%3e%3c/svg%3e";
+
       mask-image: url($svg-rect);
-      -webkit-mask-image: url($svg-rect);
       border-radius: inherit;
       mask-size: 100% 100%;
-      -webkit-mask-size: 100% 100%;
     }
   }
 }
@@ -129,23 +127,26 @@ $_focus-fallbacks: (
     margin-left: -#{$center}px;
 
     $svg: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='#{$container-size}' height='#{$container-size}'%3E%3Ccircle cx='#{$center}' cy='#{$center}' r='#{$radius}' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' stroke-linecap='butt'/%3E%3C/svg%3E";
+
     mask-image: url($svg);
-    -webkit-mask-image: url($svg);
   }
 }
 
 // Inline multi-line elements (links)
 @mixin hds-focus-ring-inline($color: 'default') {
   $suffix: '';
+
   @if $color != 'default' {
     $suffix: '-#{$color}';
   }
+
   $prop: --hds-palette-focus#{$suffix};
   $fallback: map.get($_focus-fallbacks, $color);
 
   outline: 1px dashed var(#{$prop}, #{$fallback});
   outline-offset: 1px;
   box-decoration-break: clone;
+  // stylelint-disable-next-line property-no-vendor-prefix
   -webkit-box-decoration-break: clone;
 }
 

--- a/src/scss/_hds-tokens.scss
+++ b/src/scss/_hds-tokens.scss
@@ -238,22 +238,6 @@ $hds-border-sizes: (
 );
 
 // ============================================================
-// § FOCUS RING WIDTHS
-// ============================================================
-// Named widths for the hds-focus-ring() mixin. Preserves
-// per-component variation from Figma spec:
-//   thin  — Link, Icon buttons, Checkbox/Radio outer,
-//           Pagination, Global baseline
-//   thick — Button (CTA/Secondary/Outline), Primary arrow,
-//           Breadcrumb
-// ============================================================
-
-$hds-focus-widths: (
-  'thin': 1px,
-  'thick': 2px,
-);
-
-// ============================================================
 // § BORDER RADII
 // ============================================================
 

--- a/src/scss/_hds-uswds-theme.scss
+++ b/src/scss/_hds-uswds-theme.scss
@@ -73,7 +73,9 @@
   $theme-color-base-lightest: 'white',
   // Spacesuit White — exact
   $theme-color-base-lighter: 'gray-5',
-  // Carbon 05 #F6F6F6 ≈ #f0f0f0  $theme-color-base-light:    "gray-10",  // Carbon 10 #E3E3E3 ≈ #e6e6e6
+  // Carbon 05 #F6F6F6 ≈ #f0f0f0
+  $theme-color-base-light: 'gray-10',
+  // Carbon 10 #E3E3E3 ≈ #e6e6e6
   $theme-color-base: 'gray-50',
   // Carbon 50 #77777A ≈ #757575
   $theme-color-base-dark: 'gray-80',

--- a/src/scss/base/_custom-properties.scss
+++ b/src/scss/base/_custom-properties.scss
@@ -73,10 +73,6 @@
   @each $name, $value in $hds-width-settings {
     --hds-border-width-#{$name}: #{$value};
   }
-
-  // Focus Ring SVG Masks
-  --hds-focus-mask-rect: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'><rect x='0.5' y='0.5' width='calc(100%25 - 1px)' height='calc(100%25 - 1px)' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' vector-effect='non-scaling-stroke'/></svg>");
-  --hds-focus-mask-circle: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'><circle cx='50%25' cy='50%25' r='calc(50%25 - 0.5px)' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' vector-effect='non-scaling-stroke'/></svg>");
 }
 
 // ============================================================

--- a/src/scss/base/_custom-properties.scss
+++ b/src/scss/base/_custom-properties.scss
@@ -73,6 +73,10 @@
   @each $name, $value in $hds-width-settings {
     --hds-border-width-#{$name}: #{$value};
   }
+
+  // Focus Ring SVG Masks
+  --hds-focus-mask-rect: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'><rect x='0.5' y='0.5' width='calc(100%25 - 1px)' height='calc(100%25 - 1px)' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' vector-effect='non-scaling-stroke'/></svg>");
+  --hds-focus-mask-circle: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'><circle cx='50%25' cy='50%25' r='calc(50%25 - 0.5px)' fill='none' stroke='black' stroke-width='1' stroke-dasharray='2,3' vector-effect='non-scaling-stroke'/></svg>");
 }
 
 // ============================================================

--- a/src/scss/base/_elements.scss
+++ b/src/scss/base/_elements.scss
@@ -500,14 +500,14 @@ $_p: '[data-hds-palette], [class*="hds-palette-"]';
   button:where(:not([role='presentation']) :not([class*='usa-']) :not([class*='hds-btn']) :not([disabled])),
   input[type='submit'] {
     @include button-styles;
-    @include button-hover;
+    @include button-interactive-states;
   }
 
   a.button {
     text-decoration-line: none;
 
     @include button-styles;
-    @include button-hover;
+    @include button-interactive-states;
   }
 }
 

--- a/src/scss/base/_elements.scss
+++ b/src/scss/base/_elements.scss
@@ -143,8 +143,11 @@ $_p: '[data-hds-palette], [class*="hds-palette-"]';
 // ------------------------------------------------------------
 
 @if $theme-global-link-styles or $theme-global-content-styles {
-  a {
+  a:not(:has(> img, > svg)) {
     @include hds-link-appearance;
+
+    // Suppress USWDS [href]:focus outline in all focus states
+    outline: none;
 
     &:hover {
       @include hds-link-hover;
@@ -152,6 +155,10 @@ $_p: '[data-hds-palette], [class*="hds-palette-"]';
 
     &:visited {
       color: var(--hds-palette-link-text, #{$hds-color-carbon-90});
+    }
+
+    &:focus-visible {
+      @include hds-focus-ring-inline;
     }
   }
 }

--- a/src/scss/base/_focus.scss
+++ b/src/scss/base/_focus.scss
@@ -40,3 +40,12 @@ select:focus:not(:focus-visible),
 textarea:focus:not(:focus-visible) {
   outline: none;
 }
+
+// Ensure the dashed link underline perfectly replaces the original
+// solid/dashed underline so they don't double up or bleed through.
+// The outline approach we take for links creates a box, so we need
+// to remove text-decoration when focused.
+a:focus-visible,
+.usa-button--unstyled:focus-visible {
+  text-decoration: none;
+}

--- a/src/scss/base/_focus.scss
+++ b/src/scss/base/_focus.scss
@@ -41,10 +41,8 @@ textarea:focus:not(:focus-visible) {
   outline: none;
 }
 
-// Ensure the dashed link underline perfectly replaces the original
-// solid/dashed underline so they don't double up or bleed through.
-// The outline approach we take for links creates a box, so we need
-// to remove text-decoration when focused.
+// Ensure no text-decoration bleeds through from USWDS or
+// browser defaults. The gradient underline replaces it.
 a:focus-visible,
 .usa-button--unstyled:focus-visible {
   text-decoration: none;

--- a/src/scss/base/_focus.scss
+++ b/src/scss/base/_focus.scss
@@ -5,8 +5,8 @@
 // ALWAYS ACTIVE — not gated (accessibility requirement).
 //
 // Dashed palette-aware focus ring for keyboard navigation.
-// Uses --hds-palette-focus token (Pattern A: C60 light /
-// C30 dark). Components with different focus treatments
+// Uses --hds-palette-focus token (default treatment: C60
+// light / C30 dark). Components with different focus treatments
 // override via hds-focus-ring() mixin with appropriate
 // $color and $shape parameters.
 //

--- a/src/scss/base/_focus.scss
+++ b/src/scss/base/_focus.scss
@@ -8,10 +8,10 @@
 // Uses --hds-palette-focus token (Pattern A: C60 light /
 // C30 dark). Components with different focus treatments
 // override via hds-focus-ring() mixin with appropriate
-// $color and $width parameters.
+// $color and $shape parameters.
 //
-// Offset: 2px default. Components with generous internal
-// spacing (e.g. pagination page numbers) may override to 0.
+// Global baseline is a 1px dashed ring with 1px offset,
+// rendered via SVG mask in the ::after pseudo-element.
 // ============================================================
 
 @use 'uswds-core' as *;

--- a/src/scss/base/_palettes.scss
+++ b/src/scss/base/_palettes.scss
@@ -43,7 +43,7 @@
   --hds-palette-social-fill: #{$hds-color-carbon-60};
   --hds-palette-social-icon: #{$hds-color-carbon-05};
 
-  // Focus: Bold uses C30 on all palettes per Figma (Pattern B).
+  // Focus: Bold uses C30 on all palettes per Figma.
   // Known WCAG 1.4.11 failure on light backgrounds — tracked
   // separately in Issue #40.
   --hds-palette-focus-bold: #{$hds-color-carbon-30};

--- a/src/scss/components/_accordion.scss
+++ b/src/scss/components/_accordion.scss
@@ -64,7 +64,7 @@
   justify-content: space-between;
 
   &:focus-visible {
-    @include hds-focus-ring($pseudo: 'before');
+    @include hds-focus-ring;
   }
 
   &:hover {

--- a/src/scss/components/_accordion.scss
+++ b/src/scss/components/_accordion.scss
@@ -27,6 +27,7 @@
 
 @use 'uswds-core' as *;
 @use 'hds-tokens' as *;
+@use 'hds-mixins' as *;
 
 // ── Container ─────────────────────────────────────────────────
 // Remove USWDS left border
@@ -61,6 +62,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  &:focus-visible {
+    @include hds-focus-ring($pseudo: 'before');
+  }
 
   &:hover {
     background-color: transparent;

--- a/src/scss/components/_blockquote.scss
+++ b/src/scss/components/_blockquote.scss
@@ -153,7 +153,13 @@
 // ------------------------------------------------------------
 // Inter Bold 12px uppercase. Similar to .hds-metadata but
 // with component-specific line-height (19px per Figma).
-// Can be <span> (person) or wrapped in <a> for bio link.
+// Always a <span> for grid placement. When the name is a
+// bio link, the <a> lives inside the span — not the other
+// way around — so the link is a true inline element and
+// hds-link-appearance works correctly:
+//
+//   <span class="hds-blockquote__name">Scott Kelly</span>
+//   <span class="hds-blockquote__name"><a href="...">Scott Kelly</a></span>
 // ------------------------------------------------------------
 
 .hds-blockquote__name {
@@ -187,10 +193,19 @@
   @include hds-link-appearance;
 
   color: var(--hds-palette-muted, #{$hds-color-carbon-60});
-  text-decoration-color: var(--hds-palette-muted, #{$hds-color-carbon-60});
+  outline: none; // suppress USWDS [href]:focus outline in all focus states
 
   &:hover {
     @include hds-link-hover;
+
+    color: var(--hds-palette-muted, #{$hds-color-carbon-60});
+  }
+
+  // Focus ring replaces the dashed underline — same pattern as
+  // bare <a>. Mixin sets outline: none and paints four-sided
+  // repeating-linear-gradient ring via background-image.
+  &:focus-visible {
+    @include hds-focus-ring-inline;
 
     color: var(--hds-palette-muted, #{$hds-color-carbon-60});
   }

--- a/src/scss/components/_breadcrumb.scss
+++ b/src/scss/components/_breadcrumb.scss
@@ -30,6 +30,13 @@
   background-color: transparent;
   color: var(--hds-palette-muted, #{$hds-color-carbon-60});
   font-size: size('body', '2xs');
+  line-height: lh('body', 3);
+}
+
+// USWDS clips the list to hide overflow for truncation. Override
+// overflow only so focus ring gradients can paint outside list bounds.
+.usa-breadcrumb:not(.usa-breadcrumb--wrap) .usa-breadcrumb__list {
+  overflow: visible;
 }
 
 // ------------------------------------------------------------
@@ -41,7 +48,6 @@
 .usa-breadcrumb__link:active {
   color: inherit;
   text-decoration: none;
-  padding: 0 4px;
   background-image: none;
 }
 
@@ -56,14 +62,20 @@
     transparent 2px,
     transparent 5px
   );
-  background-size: calc(100% - 8px) 1px;
-  background-position: center 100%;
+
+  // Prose links use calc(100% - 8px) / center because they carry always-on
+  // padding: 0 4px. Breadcrumb scopes padding to :focus-visible only, so the
+  // underline spans full content width instead.
+  background-size: 100% 1px;
+  background-position: 0 100%;
   background-repeat: no-repeat;
 }
 
-.usa-breadcrumb__link:focus-visible,
-.usa-breadcrumb__link:hover:focus-visible {
+.usa-breadcrumb__link:focus-visible {
   @include hds-focus-ring-inline;
+
+  padding: 0 4px;
+  margin: 0 -4px;
 }
 
 // ------------------------------------------------------------

--- a/src/scss/components/_breadcrumb.scss
+++ b/src/scss/components/_breadcrumb.scss
@@ -54,7 +54,7 @@
 }
 
 .usa-breadcrumb__link:focus-visible {
-  @include hds-focus-ring($width: 'thick');
+  @include hds-focus-ring-inline;
 }
 
 // Fix: USWDS overflow:hidden clips focus outline on first/last links

--- a/src/scss/components/_breadcrumb.scss
+++ b/src/scss/components/_breadcrumb.scss
@@ -41,25 +41,29 @@
 .usa-breadcrumb__link:active {
   color: inherit;
   text-decoration: none;
+  padding: 0 4px;
+  background-image: none;
 }
 
 .usa-breadcrumb__link:hover {
   color: var(--hds-palette-heading, #{$hds-color-carbon-black});
   font-weight: font-weight('semibold');
-  text-decoration-color: currentcolor;
-  text-decoration-line: underline;
-  text-decoration-style: dashed;
-  text-decoration-thickness: 0.05em;
-  text-underline-offset: 0.25rem;
+  text-decoration: none;
+  background-image: repeating-linear-gradient(
+    to right,
+    currentcolor 0,
+    currentcolor 2px,
+    transparent 2px,
+    transparent 5px
+  );
+  background-size: calc(100% - 8px) 1px;
+  background-position: center 100%;
+  background-repeat: no-repeat;
 }
 
-.usa-breadcrumb__link:focus-visible {
+.usa-breadcrumb__link:focus-visible,
+.usa-breadcrumb__link:hover:focus-visible {
   @include hds-focus-ring-inline;
-}
-
-// Fix: USWDS overflow:hidden clips focus outline on first/last links
-.usa-breadcrumb:not(.usa-breadcrumb--wrap) .usa-breadcrumb__list {
-  padding-inline: 4px;
 }
 
 // ------------------------------------------------------------

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -53,7 +53,7 @@
 // ------------------------------------------------------------
 
 .usa-button:focus-visible:not(:disabled, [aria-disabled='true']) {
-  @include hds-focus-ring($color: 'bold', $width: 'thick');
+  @include hds-focus-ring($color: 'bold');
 }
 
 // ------------------------------------------------------------
@@ -65,7 +65,7 @@
 // ------------------------------------------------------------
 
 .usa-button--unstyled:focus-visible:not(:disabled, [aria-disabled='true']) {
-  @include hds-focus-ring;
+  @include hds-focus-ring-inline;
 }
 
 // ------------------------------------------------------------

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -70,9 +70,9 @@
 .usa-button--unstyled:focus-visible:not(:disabled, [aria-disabled='true']) {
   @include hds-focus-ring-inline;
 
-  // Kill the ::after pseudo-element from the base .usa-button rule
+  // Kill the ::before pseudo-element from the base .usa-button rule
   // to prevent double focus rings (outline + pseudo-element mask).
-  &::after {
+  &::before {
     display: none;
   }
 }

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -66,6 +66,12 @@
 
 .usa-button--unstyled:focus-visible:not(:disabled, [aria-disabled='true']) {
   @include hds-focus-ring-inline;
+
+  // Kill the ::after pseudo-element from the base .usa-button rule
+  // to prevent double focus rings (outline + pseudo-element mask).
+  &::after {
+    display: none;
+  }
 }
 
 // ------------------------------------------------------------

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -60,24 +60,6 @@
 }
 
 // ------------------------------------------------------------
-// Focus — Unstyled Button
-// ------------------------------------------------------------
-// Unstyled button looks identical to a link (via
-// hds-link-appearance mixin) so its focus ring must also
-// match .usa-link: inline outline, default treatment.
-// ------------------------------------------------------------
-
-.usa-button--unstyled:focus-visible:not(:disabled, [aria-disabled='true']) {
-  @include hds-focus-ring-inline;
-
-  // Kill the ::before pseudo-element from the base .usa-button rule
-  // to prevent double focus rings (outline + pseudo-element mask).
-  &::before {
-    display: none;
-  }
-}
-
-// ------------------------------------------------------------
 // CTA — Filled Red (.usa-button)
 // ------------------------------------------------------------
 // Base color handled by USWDS via primary/secondary swap.
@@ -225,8 +207,8 @@
   @include hds-link-appearance;
 
   background-color: transparent;
-  padding: 0 4px; // re-assert over USWDS reset
-  margin: 0 -4px; // cancel padding's flow contribution
+  padding: 2px 4px; // re-assert over USWDS reset
+  margin: -2px -4px; // cancel padding's flow contribution
 
   &:visited {
     color: var(--hds-palette-link-text, #{$hds-color-carbon-90});
@@ -237,6 +219,16 @@
     @include hds-link-hover;
 
     background-color: transparent;
+  }
+
+  &:focus-visible:not(:disabled, [aria-disabled='true']) {
+    @include hds-focus-ring-inline;
+
+    // Kill the ::before pseudo-element from the base .usa-button rule
+    // to prevent double focus rings (outline + pseudo-element mask).
+    &::before {
+      display: none;
+    }
   }
 
   &:disabled,

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -31,7 +31,7 @@
 //   Filled secondary  — palette-aware (Blue → Blue Tint on dark)
 //   Outline           — palette-aware (border + text adapt)
 //   Focus ring        — palette-aware via --hds-palette-focus-bold
-//                       (Pattern B: C30 universal — known WCAG
+//                       (bold: C30 universal — known WCAG
 //                       1.4.11 failure on light, tracked in #40)
 //   Hover shades      — universal (TODO: creative director review
 //                       for dark-palette hover values)
@@ -45,15 +45,18 @@
 @use 'hds-mixins' as *;
 
 // ------------------------------------------------------------
-// Focus — Filled + Outline Buttons
+// Interactive states — hover, active, focus
 // ------------------------------------------------------------
-// Pattern B (Bold): C30 on all palettes per Figma.
-// Known WCAG 1.4.11 failure on light backgrounds — tracked
-// in Issue #40.
+// Shared with the base stock-button reset in base/_elements.scss
+// via button-interactive-states mixin so the two cannot drift.
+// Hover/active: NASA Red Shade (universal — no palette swap).
+// Focus: Bold treatment, C30 on all palettes per Figma.
+// Known WCAG 1.4.11 failure on light backgrounds — tracked in
+// Issue #40.
 // ------------------------------------------------------------
 
-.usa-button:focus-visible:not(:disabled, [aria-disabled='true']) {
-  @include hds-focus-ring($color: 'bold');
+.usa-button {
+  @include button-interactive-states;
 }
 
 // ------------------------------------------------------------
@@ -61,7 +64,7 @@
 // ------------------------------------------------------------
 // Unstyled button looks identical to a link (via
 // hds-link-appearance mixin) so its focus ring must also
-// match .usa-link: thin width, default color (Pattern A).
+// match .usa-link: inline outline, default treatment.
 // ------------------------------------------------------------
 
 .usa-button--unstyled:focus-visible:not(:disabled, [aria-disabled='true']) {
@@ -78,16 +81,11 @@
 // CTA — Filled Red (.usa-button)
 // ------------------------------------------------------------
 // Base color handled by USWDS via primary/secondary swap.
-// Hover/active override USWDS auto-darkening with exact
-// HDS value (NASA Red Shade).
-// TODO: Confirm NASA Red Shade works on dark palettes
-// during creative director review.
+// Hover/active background override comes from
+// button-interactive-states mixin (NASA Red Shade, universal).
+// TODO: Confirm NASA Red Shade works on dark palettes during
+// creative director review.
 // ------------------------------------------------------------
-
-.usa-button:hover:not(:disabled, [aria-disabled='true']),
-.usa-button:active:not(:disabled, [aria-disabled='true']) {
-  background-color: $hds-color-nasa-red-shade;
-}
 
 // ------------------------------------------------------------
 // Secondary Filled — Blue (.usa-button--secondary)

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -225,6 +225,8 @@
   @include hds-link-appearance;
 
   background-color: transparent;
+  padding: 0 4px; // re-assert over USWDS reset
+  margin: 0 -4px; // cancel padding's flow contribution
 
   &:visited {
     color: var(--hds-palette-link-text, #{$hds-color-carbon-90});

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -94,7 +94,7 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
 }
 
 .usa-checkbox__label-description,
-.usa-checkbox__label-description {
+.usa-radio__label-description {
   color: var(--hds-palette-muted);
 }
 

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -213,8 +213,7 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
 // Outer box: Pattern D (Minimal) — C30 light / C80 dark.
 // Inner box: Solid blue element highlight (separate system).
 .usa-checkbox__input:focus-visible + .usa-checkbox__label {
-  @include hds-focus-ring($color: 'minimal');
-
+  @include hds-focus-ring-wrapped($color: 'minimal');
   border-radius: 0;
 }
 
@@ -306,8 +305,7 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
 // Outer box: Pattern D (Minimal) — C30 light / C80 dark.
 // Inner circle: Solid blue element highlight (separate system).
 .usa-radio__input:focus-visible + .usa-radio__label {
-  @include hds-focus-ring($color: 'minimal');
-
+  @include hds-focus-ring-wrapped($color: 'minimal', $shape: 'circle');
   border-radius: 0;
 }
 

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -33,7 +33,7 @@
 //   --hds-palette-control-stroke  → checkbox/radio selected border
 //   --hds-palette-control-border  → checkbox/radio default border
 //   --hds-palette-focus-minimal   → checkbox/radio outer focus box
-//                                   (Pattern D: C30 light / C80 dark)
+//                                   (minimal: C30 light / C80 dark)
 //
 // Tokens inferred from Figma (NOT in Proposal — flagged for
 // creative director review):

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -225,7 +225,6 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
   align-items: flex-start; // Align to top if text wraps
   gap: 8px; // Exact Figma gap!
   padding-left: 0; // Nuke the USWDS indent hack
-
   color: var(--hds-palette-control-text);
   font-family: family('heading');
   font-weight: font-weight('normal');
@@ -333,7 +332,6 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
   align-items: flex-start;
   gap: 8px;
   padding-left: 0;
-
   color: var(--hds-palette-control-text);
   font-family: family('heading');
   font-weight: font-weight('normal');

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -66,6 +66,26 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
   background-color: transparent;
 }
 
+// Kill any USWDS phantom outlines, pseudo-elements, or focus rings
+// on the hidden native inputs that cause layout shifting.
+.usa-checkbox__input,
+.usa-radio__input {
+  // Force the input to stay visually hidden and completely out of the
+  // document flow even on focus, preventing it from pushing siblings.
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  margin: 0;
+  padding: 0;
+  outline: none;
+
+  &::before,
+  &::after {
+    display: none;
+  }
+}
+
 .usa-checkbox__input--tile + .usa-checkbox__label,
 .usa-radio__input--tile + .usa-radio__label {
   background-color: transparent;
@@ -187,17 +207,36 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
   background-color: var(--hds-palette-input-bg);
   border: 0;
   box-shadow: 0 0 0 1px var(--hds-palette-control-border);
+
+  // Override USWDS absolute positioning
+  position: static;
+  flex-shrink: 0; // prevent squeezing when text is long
+  margin-top: 0;
+
+  // Re-apply exact Figma 18px sizing!
   height: 18px;
   width: 18px;
 }
 
 // Label text — Figma: Inter 400 14px, -0.25px ls
 .usa-checkbox__label {
+  // Modern Flexbox Layout
+  display: inline-flex;
+  align-items: flex-start; // Align to top if text wraps
+  gap: 8px; // Exact Figma gap!
+  padding-left: 0; // Nuke the USWDS indent hack
+
   color: var(--hds-palette-control-text);
   font-family: family('heading');
   font-weight: font-weight('normal');
   font-size: size('body', '2xs');
   letter-spacing: map.get($hds-letterspacing, 'neg-1');
+}
+
+// Focus — Dashed outer ring on the label row
+.usa-checkbox__input:focus-visible + .usa-checkbox__label {
+  outline: 1px dashed var(--hds-palette-focus-minimal, #{$hds-color-carbon-30});
+  outline-offset: 4px;
 }
 
 // Hover — border darkens, label darkens
@@ -209,14 +248,14 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
   color: var(--hds-palette-heading);
 }
 
-// Focus — dashed ring around entire label + blue border on box.
-// Outer box: Pattern D (Minimal) — C30 light / C80 dark.
-// Inner box: Solid blue element highlight (separate system).
-.usa-checkbox__input:focus-visible + .usa-checkbox__label {
-  @include hds-focus-ring-wrapped($color: 'minimal');
-  border-radius: 0;
+// Kill USWDS hover/focus layout shifts
+.usa-checkbox__label::after,
+.usa-radio__label::after {
+  display: none;
 }
 
+// Focus — solid blue element highlight on the box itself.
+// The outer dashed ring is handled by the wrapper rule above.
 .usa-checkbox__input:focus-visible + .usa-checkbox__label::before {
   border: 0;
   box-shadow: 0 0 0 2px var(--hds-palette-btn-secondary-bg);
@@ -276,17 +315,36 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
   background-color: var(--hds-palette-input-bg);
   border: 0;
   box-shadow: 0 0 0 1px var(--hds-palette-control-border);
+
+  // Override USWDS absolute positioning
+  position: static;
+  flex-shrink: 0;
+  margin-top: 0;
+
+  // Re-apply exact Figma 18px sizing!
   height: 18px;
   width: 18px;
 }
 
 // Label text — same as checkbox
 .usa-radio__label {
+  // Modern Flexbox Layout
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding-left: 0;
+
   color: var(--hds-palette-control-text);
   font-family: family('heading');
   font-weight: font-weight('normal');
   font-size: size('body', '2xs');
   letter-spacing: map.get($hds-letterspacing, 'neg-1');
+}
+
+// Focus — Dashed outer ring on the label row
+.usa-radio__input:focus-visible + .usa-radio__label {
+  outline: 1px dashed var(--hds-palette-focus-minimal, #{$hds-color-carbon-30});
+  outline-offset: 4px;
 }
 
 // Hover — unchecked: border darkens
@@ -301,14 +359,8 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
     0 0 0 1px var(--hds-palette-muted);
 }
 
-// Focus — dashed ring around entire label + blue border on circle.
-// Outer box: Pattern D (Minimal) — C30 light / C80 dark.
-// Inner circle: Solid blue element highlight (separate system).
-.usa-radio__input:focus-visible + .usa-radio__label {
-  @include hds-focus-ring-wrapped($color: 'minimal', $shape: 'circle');
-  border-radius: 0;
-}
-
+// Focus — solid blue element highlight on the circle itself.
+// The outer dashed ring is handled by the wrapper rule above.
 .usa-radio__input:focus-visible + .usa-radio__label::before {
   border: 0;
   box-shadow: 0 0 0 2px var(--hds-palette-btn-secondary-bg);

--- a/src/scss/components/_icon-button.scss
+++ b/src/scss/components/_icon-button.scss
@@ -39,6 +39,7 @@
   align-items: center;
   background: none;
   border: 1px solid transparent;
+  box-sizing: border-box;
   border-radius: 50%;
   cursor: pointer;
   display: inline-flex;
@@ -46,6 +47,7 @@
   justify-content: center;
   padding: 0;
   width: 24px;
+  position: relative;
 
   &[disabled],
   &:disabled {
@@ -234,18 +236,21 @@
 .hds-btn-icon--2xs {
   height: 12px;
   width: 12px;
+  &:focus-visible { @include hds-focus-ring-size(12); }
 }
 
 // 16px — header, footer, compact UI
 .hds-btn-icon--xs {
   height: 16px;
   width: 16px;
+  &:focus-visible { @include hds-focus-ring-size(16); }
 }
 
 // 20px — inline with text, cards
 .hds-btn-icon--sm {
   height: 20px;
   width: 20px;
+  &:focus-visible { @include hds-focus-ring-size(20); }
 }
 
 // 24px — default (no class needed)
@@ -254,24 +259,28 @@
 .hds-btn-icon--lg {
   height: 28px;
   width: 28px;
+  &:focus-visible { @include hds-focus-ring-size(28); }
 }
 
 // 32px — social buttons, standalone actions
 .hds-btn-icon--xl {
   height: 32px;
   width: 32px;
+  &:focus-visible { @include hds-focus-ring-size(32); }
 }
 
 // 36px — hero, prominent controls
 .hds-btn-icon--2xl {
   height: 36px;
   width: 36px;
+  &:focus-visible { @include hds-focus-ring-size(36); }
 }
 
 // 40px — pagination arrows, carousel controls
 .hds-btn-icon--3xl {
   height: 40px;
   width: 40px;
+  &:focus-visible { @include hds-focus-ring-size(40); }
 }
 
 // ── Inline glyph ──────────────────────────────────────────────

--- a/src/scss/components/_icon-button.scss
+++ b/src/scss/components/_icon-button.scss
@@ -20,13 +20,13 @@
 // Focus treatments:
 //   Utility       — default (C60 light / C30 dark)
 //   CTA/Sec/Out/Social — bold (C30 universal)
-//   Interactive   — fixed (C40, 1px offset, exempt from palette)
+//   Interactive   — fixed (C40, exempt from palette)
 //
 // States:
-//   All roles except --interactive support hover, active,
-//   focus-visible, and disabled. Active matches hover (no
-//   distinct active state, consistent with Apple HIG).
-//   Disabled is color-based, not opacity-based.
+//   All roles support hover, active, and focus-visible.
+//   Every role except --interactive supports disabled.
+//   Active matches hover (no distinct active state, consistent
+//   with Apple HIG). Disabled is color-based, not opacity-based.
 // ============================================================
 
 @use 'uswds-core' as *;
@@ -209,11 +209,14 @@
     color: #{$hds-color-carbon-black};
   }
 
-  // Fixed focus ring — exempt from palette system.
-  // C40 at 1px offset for high contrast on dynamic backgrounds.
+  // Fixed focus ring — C40 hardcoded because this button lives over
+  // images, video, and WebGL where palette containers don't apply.
   &:focus-visible {
-    outline: 1px dashed #{$hds-color-carbon-40};
-    outline-offset: 1px;
+    @include hds-focus-ring($shape: 'circle');
+
+    &::before {
+      background-color: #{$hds-color-carbon-40};
+    }
   }
 }
 
@@ -236,21 +239,30 @@
 .hds-btn-icon--2xs {
   height: 12px;
   width: 12px;
-  &:focus-visible { @include hds-focus-ring-size(12); }
+
+  &:focus-visible {
+    @include hds-focus-ring-size(12);
+  }
 }
 
 // 16px — header, footer, compact UI
 .hds-btn-icon--xs {
   height: 16px;
   width: 16px;
-  &:focus-visible { @include hds-focus-ring-size(16); }
+
+  &:focus-visible {
+    @include hds-focus-ring-size(16);
+  }
 }
 
 // 20px — inline with text, cards
 .hds-btn-icon--sm {
   height: 20px;
   width: 20px;
-  &:focus-visible { @include hds-focus-ring-size(20); }
+
+  &:focus-visible {
+    @include hds-focus-ring-size(20);
+  }
 }
 
 // 24px — default (no class needed)
@@ -259,28 +271,40 @@
 .hds-btn-icon--lg {
   height: 28px;
   width: 28px;
-  &:focus-visible { @include hds-focus-ring-size(28); }
+
+  &:focus-visible {
+    @include hds-focus-ring-size(28);
+  }
 }
 
 // 32px — social buttons, standalone actions
 .hds-btn-icon--xl {
   height: 32px;
   width: 32px;
-  &:focus-visible { @include hds-focus-ring-size(32); }
+
+  &:focus-visible {
+    @include hds-focus-ring-size(32);
+  }
 }
 
 // 36px — hero, prominent controls
 .hds-btn-icon--2xl {
   height: 36px;
   width: 36px;
-  &:focus-visible { @include hds-focus-ring-size(36); }
+
+  &:focus-visible {
+    @include hds-focus-ring-size(36);
+  }
 }
 
 // 40px — pagination arrows, carousel controls
 .hds-btn-icon--3xl {
   height: 40px;
   width: 40px;
-  &:focus-visible { @include hds-focus-ring-size(40); }
+
+  &:focus-visible {
+    @include hds-focus-ring-size(40);
+  }
 }
 
 // ── Inline glyph ──────────────────────────────────────────────

--- a/src/scss/components/_icon-button.scss
+++ b/src/scss/components/_icon-button.scss
@@ -18,8 +18,8 @@
 //   --lg          Hero CTAs
 //
 // Focus treatments:
-//   Utility       — default (Pattern A: C60 light / C30 dark)
-//   CTA/Sec/Out/Social — bold (Pattern B: C30 universal)
+//   Utility       — default (C60 light / C30 dark)
+//   CTA/Sec/Out/Social — bold (C30 universal)
 //   Interactive   — fixed (C40, 1px offset, exempt from palette)
 //
 // States:
@@ -63,8 +63,8 @@
 }
 
 // ── Focus — Per-Role ──────────────────────────────────────────
-// Split by Figma treatment. Utility uses default (Pattern A).
-// CTA, Secondary, Outline, Social use bold (Pattern B).
+// Split by Figma treatment. Utility uses default.
+// CTA, Secondary, Outline, Social use bold.
 // Interactive is exempt — fixed colors for dynamic backgrounds.
 
 .hds-btn-icon--utility {

--- a/src/scss/components/_icon-button.scss
+++ b/src/scss/components/_icon-button.scss
@@ -67,7 +67,7 @@
 
 .hds-btn-icon--utility {
   &:focus-visible {
-    @include hds-focus-ring;
+    @include hds-focus-ring($shape: 'circle');
   }
 }
 
@@ -76,7 +76,7 @@
 .hds-btn-icon--outline,
 .hds-btn-icon--social {
   &:focus-visible {
-    @include hds-focus-ring($color: 'bold');
+    @include hds-focus-ring($color: 'bold', $shape: 'circle');
   }
 }
 

--- a/src/scss/components/_link.scss
+++ b/src/scss/components/_link.scss
@@ -35,7 +35,7 @@
   }
 
   &:focus-visible {
-    @include hds-focus-ring;
+    @include hds-focus-ring-inline;
   }
 }
 

--- a/src/scss/components/_link.scss
+++ b/src/scss/components/_link.scss
@@ -61,6 +61,14 @@
   background-color: var(--hds-palette-link-arrow, #{$hds-color-carbon-60});
   content: '\a0';
   display: inline;
+
+  // Reset USWDS external-link() mixin's margin-top: 0.7ex which
+  // visually shifts the arrow downward off the text baseline.
+  // Keep USWDS's padding-left: 1.75ex — it gives the inline
+  // `\a0`-only ::after horizontal room for the centered mask
+  // icon to render. Composing components that don't want the
+  // padding-left (e.g. primary arrow button) defend locally.
+  margin: 0;
   mask-image: url('../assets/img/hds-icons/arrow-line-diagonal.svg'), linear-gradient(transparent, transparent);
   mask-size: 0.75em;
   mask-position: center;

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -110,7 +110,7 @@
     &:focus-visible {
       background-color: transparent;
 
-      @include hds-focus-ring($color: 'subtle', $pseudo: 'before');
+      @include hds-focus-ring($color: 'subtle');
 
       color: var(--hds-palette-heading, #{$hds-color-carbon-black});
     }
@@ -140,7 +140,7 @@
   &:focus-visible {
     background-color: transparent;
 
-    @include hds-focus-ring($color: 'subtle', $pseudo: 'before');
+    @include hds-focus-ring($color: 'subtle');
 
     color: var(--hds-palette-text, #{$hds-color-carbon-90});
   }

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -109,7 +109,9 @@
 
     &:focus-visible {
       background-color: transparent;
+
       @include hds-focus-ring($color: 'subtle', $pseudo: 'before');
+
       color: var(--hds-palette-heading, #{$hds-color-carbon-black});
     }
   }
@@ -137,7 +139,9 @@
   // Focus — non-current pages
   &:focus-visible {
     background-color: transparent;
+
     @include hds-focus-ring($color: 'subtle', $pseudo: 'before');
+
     color: var(--hds-palette-text, #{$hds-color-carbon-90});
   }
 }
@@ -260,6 +264,7 @@
   &:focus-visible,
   button#{&}:focus-visible {
     @include hds-focus-ring($color: 'subtle');
+
     outline: none !important; // override global focus
   }
 

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -109,9 +109,7 @@
 
     &:focus-visible {
       background-color: transparent;
-
-      @include hds-focus-ring($color: 'subtle', $method: 'border');
-
+      @include hds-focus-ring($color: 'subtle', $pseudo: 'before');
       color: var(--hds-palette-heading, #{$hds-color-carbon-black});
     }
   }
@@ -139,9 +137,7 @@
   // Focus — non-current pages
   &:focus-visible {
     background-color: transparent;
-
-    @include hds-focus-ring($color: 'subtle', $method: 'border');
-
+    @include hds-focus-ring($color: 'subtle', $pseudo: 'before');
     color: var(--hds-palette-text, #{$hds-color-carbon-90});
   }
 }
@@ -180,7 +176,7 @@
 
   // Focus — dashed ring outside solid circle border
   &:focus-visible {
-    @include hds-focus-ring;
+    @include hds-focus-ring($shape: 'circle');
   }
 
   // Disabled — color-based, not opacity-based
@@ -259,13 +255,11 @@
   }
 
   // Focus — dashed box around the WHOLE button (text + circle).
-  // Uses border method so it wraps the composed shape.
   // Must override global focus-visible outline (base/_focus.scss)
   // because this is a <button> element.
   &:focus-visible,
   button#{&}:focus-visible {
-    @include hds-focus-ring($color: 'subtle', $method: 'border');
-
+    @include hds-focus-ring($color: 'subtle');
     outline: none !important; // override global focus
   }
 

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -15,9 +15,9 @@
 //     restyled via @include hds-utility-circle automatically
 //
 // Focus treatments:
-//   Prev/next arrows — default (Pattern A), outline method
-//   Page numbers     — subtle (Pattern E), border method
-//   Simplified btn   — subtle (Pattern E), border method
+//   Prev/next arrows — default, outline method
+//   Page numbers     — subtle, border method
+//   Simplified btn   — subtle, border method
 //
 // Filter variant (rows-per-page dropdown) deferred to Phase 2+.
 //

--- a/src/scss/components/_primary-arrow-button.scss
+++ b/src/scss/components/_primary-arrow-button.scss
@@ -18,19 +18,25 @@
 @use 'hds-tokens' as *;
 @use 'hds-mixins' as *;
 
-$_arrow-right: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='5' y1='12' x2='19' y2='12'/%3E%3Cpolyline points='13 6 19 12 13 18'/%3E%3C/svg%3E");
-$_arrow-diagonal: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cline x1='7' y1='17' x2='17' y2='7'/%3E%3Cpolyline points='10 7 17 7 17 14'/%3E%3C/svg%3E");
+// Inlined from src/assets/img/hds-icons/arrow-line-{right,diagonal}.svg
+// (filled paths, fill='white' for the always-white-on-red circle).
+// Keeps glyph identity with the HDS icon family used elsewhere.
+$_arrow-right: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 11.1944L15.7545 11.1944L10.9496 16.3277L12.5145 18L20 10L12.5145 2L10.9496 3.6723L15.7545 8.80562L0 8.80562L0 11.1944Z' fill='white'/%3E%3C/svg%3E");
+$_arrow-diagonal: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3.77359 17.9156L14.9137 6.77551L15.1459 13.8029L17.435 13.8788L17.0712 2.92893L6.1213 2.5651L6.1972 4.85419L13.2246 5.0864L2.08448 16.2265L3.77359 17.9156Z' fill='white'/%3E%3C/svg%3E");
 
 // ── Base ──────────────────────────────────────────────────────
 
 .hds-btn--primary {
+  align-items: center;
   background-color: transparent;
   border: 0;
   border-radius: 0;
   color: var(--hds-palette-heading, #{$hds-color-carbon-black});
+  display: inline-flex;
   font-family: family('heading');
   font-size: 18px;
   font-weight: font-weight('bold');
+  gap: 4px;
   line-height: var(--hds-line-height-button);
   padding: 0;
   text-decoration-line: none;
@@ -43,21 +49,23 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
     background-size: 55%;
     border-radius: 50%;
     content: '';
-    display: inline-block; // override .usa-link--external::after
+    flex-shrink: 0;
     height: 24px;
-    margin-inline-start: 0.3em;
-    vertical-align: text-bottom;
     width: 24px;
   }
 
-  // External links: swap horizontal arrow to diagonal
+  // External links: swap horizontal arrow to diagonal.
+  // Only override the background-image so size variants
+  // (--xs/--sm/--lg/--xl/--2xl) still control circle dimensions.
+  // mask-image: none blocks the diagonal-arrow mask from
+  // _link.scss's .usa-link--external::after base rule, which
+  // would otherwise clip the red circle down to just the
+  // arrow shape. padding: 0 blocks USWDS external-link()
+  // mixin's padding-left leak.
   &.usa-link--external::after {
-    background-color: var(--hds-palette-btn-primary-bg, #{$hds-color-nasa-red});
     background-image: #{$_arrow-diagonal};
-    display: inline-block; // override link external ::after
-    height: 24px; // explicit — link ::after has no height
     mask-image: none;
-    width: 24px; // explicit — link ::after has no width
+    padding: 0;
   }
 
   &:hover {
@@ -70,7 +78,9 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
   }
 
   &:focus-visible {
-    @include hds-focus-ring($pseudo: 'before');
+    @include hds-focus-ring-inline;
+
+    outline-offset: 4px;
   }
 }
 
@@ -112,6 +122,7 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
 // 22px text / 28px circle
 .hds-btn--primary--lg {
   font-size: 22px;
+  gap: 8px;
 
   &::after {
     height: 28px;
@@ -122,6 +133,7 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
 // 29px text / 32px circle
 .hds-btn--primary--xl {
   font-size: 29px;
+  gap: 8px;
 
   &::after {
     height: 32px;
@@ -132,6 +144,7 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
 // 36px text / 36px circle
 .hds-btn--primary--2xl {
   font-size: 36px;
+  gap: 8px;
 
   &::after {
     height: 36px;

--- a/src/scss/components/_primary-arrow-button.scss
+++ b/src/scss/components/_primary-arrow-button.scss
@@ -70,7 +70,7 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/s
   }
 
   &:focus-visible {
-    @include hds-focus-ring($width: 'thick');
+    @include hds-focus-ring($pseudo: 'before');
   }
 }
 

--- a/src/scss/components/_primary-arrow-button.scss
+++ b/src/scss/components/_primary-arrow-button.scss
@@ -78,9 +78,11 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='ht
   }
 
   &:focus-visible {
-    @include hds-focus-ring-inline;
+    @include hds-focus-ring('default', 'rect', 'before');
 
-    outline-offset: 4px;
+    &::before {
+      inset: -4px -6px;
+    }
   }
 }
 
@@ -128,6 +130,10 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='ht
     height: 28px;
     width: 28px;
   }
+
+  &:focus-visible::before {
+    inset: -6px;
+  }
 }
 
 // 29px text / 32px circle
@@ -139,6 +145,10 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='ht
     height: 32px;
     width: 32px;
   }
+
+  &:focus-visible::before {
+    inset: -6px;
+  }
 }
 
 // 36px text / 36px circle
@@ -149,5 +159,9 @@ $_arrow-diagonal: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='ht
   &::after {
     height: 36px;
     width: 36px;
+  }
+
+  &:focus-visible::before {
+    inset: -6px -8px;
   }
 }

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -233,7 +233,7 @@
 // Figma specifies a "surface-inverse" focus treatment for table
 // sort buttons (ring color inverse of the component's own fill).
 // Not yet implemented — sort buttons currently inherit the global
-// focus ring from base/_focus.scss (Pattern A, thin, outline).
+// focus ring from base/_focus.scss (default treatment, 1px dashed).
 // See DESIGN.md Table section and FocusSortButton story.
 //
 // ⚠️ mask-image clips the focus ring on this element — the sort

--- a/stories/components/Accordion.mdx
+++ b/stories/components/Accordion.mdx
@@ -60,4 +60,4 @@ Multiple sections can be open at the same time. Add `data-allow-multiple` and th
   USWDS JavaScript initializes accordions on page load. If you render accordions dynamically (e.g., in a React or Vue app without <a href="https://github.com/trussworks/react-uswds">react-uswds</a>), you need to reinitialize after mount — see the <a href="/?path=/docs/guides-react-guidance--docs">React Setup</a> guide for details.
 </Note>
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS accordion accessibility tests](https://designsystem.digital.gov/components/accordion/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/Blockquote.stories.js
+++ b/stories/components/Blockquote.stories.js
@@ -7,7 +7,9 @@
 //   Stories     — Default, Author, Source, All Variants (visible in sidebar)
 // ============================================================
 
-import { paletteA11yParams, paletteRender } from '../helpers/paletteTests';
+import { expect } from 'storybook/test';
+import { paletteModes } from '../../.storybook/modes';
+import { paletteA11yParams, paletteRender, pseudoParams } from '../helpers/paletteTests';
 
 export default {
   title: 'Components/Blockquote',
@@ -36,8 +38,13 @@ const quoteArg = {
   quote: { control: 'text', description: 'Quote text content' },
 };
 
+// <span> always owns the class and grid placement. When linked, <a> nests
+// inside the span so it remains a true inline element — hds-link-appearance
+// requires inline context; a grid item cannot provide it.
 const nameEl = (name, linked) =>
-  linked ? `<a href="#" class="hds-blockquote__name">${name}</a>` : `<span class="hds-blockquote__name">${name}</span>`;
+  linked
+    ? `<span class="hds-blockquote__name"><a href="#">${name}</a></span>`
+    : `<span class="hds-blockquote__name">${name}</span>`;
 
 const avatarEl = (name) => `<img class="hds-blockquote__avatar" src="blockquote-avatar-kelly.png" alt="${name}" />`;
 
@@ -52,9 +59,11 @@ const personAttribution = ({ linked = false } = {}) => `
     <span class="hds-blockquote__description">${defaults.description}</span>
   </div>`;
 
+// <cite> owns the class and grid placement. When linked, <a> nests inside
+// the cite — same pattern as nameEl above.
 const sourceAttribution = ({ linked = false } = {}) => {
   const desc = linked
-    ? `<a href="#"><cite class="hds-blockquote__description">${defaults.source}</cite></a>`
+    ? `<cite class="hds-blockquote__description"><a href="#">${defaults.source}</a></cite>`
     : `<cite class="hds-blockquote__description">${defaults.source}</cite>`;
   return `<div class="hds-blockquote__attribution">${desc}</div>`;
 };
@@ -110,7 +119,7 @@ export const Source = {
   },
   render: ({ quote, source, linked }) => {
     const desc = linked
-      ? `<a href="#"><cite class="hds-blockquote__description">${source}</cite></a>`
+      ? `<cite class="hds-blockquote__description"><a href="#">${source}</a></cite>`
       : `<cite class="hds-blockquote__description">${source}</cite>`;
 
     return blockquote(
@@ -166,4 +175,44 @@ export const PaletteA11y = {
   tags: ['!dev'],
   parameters: paletteA11yParams,
   render: paletteRender(() => `<div style="padding-left: 3rem;">${AllVariants.render()}</div>`),
+};
+
+export const PaletteA11yHover = {
+  name: 'Palette a11y [hover]',
+  tags: ['!dev'],
+  parameters: { ...paletteA11yParams, ...pseudoParams.hover },
+  render: paletteRender(() => `<div style="padding-left: 3rem;">${AllVariants.render()}</div>`),
+};
+
+// --- Focus tests (Chromatic modes + play function) ---
+
+const focusParams = {
+  chromatic: {
+    disableSnapshot: false,
+    modes: paletteModes,
+  },
+};
+
+export const FocusAuthorLinked = {
+  name: 'Focus [author linked]',
+  tags: ['!dev'],
+  parameters: focusParams,
+  render: () => blockquote(`<p>${defaults.quoteAuthor}</p>${personAttribution({ linked: true })}`),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.tab();
+    const link = canvas.getByRole('link', { name: defaults.name });
+    await expect(link).toHaveFocus();
+  },
+};
+
+export const FocusSourceLinked = {
+  name: 'Focus [source linked]',
+  tags: ['!dev'],
+  parameters: focusParams,
+  render: () => blockquote(`<p>${defaults.quoteSource}</p>${sourceAttribution({ linked: true })}`),
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.tab();
+    const link = canvas.getByRole('link', { name: defaults.source });
+    await expect(link).toHaveFocus();
+  },
 };

--- a/stories/components/Breadcrumb.mdx
+++ b/stories/components/Breadcrumb.mdx
@@ -98,4 +98,4 @@ The recommended markup shown above includes all necessary ARIA attributes. The e
 </nav>
 ```
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS breadcrumb accessibility tests](https://designsystem.digital.gov/components/breadcrumb/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/Button.mdx
+++ b/stories/components/Button.mdx
@@ -131,4 +131,4 @@ For more on how HDS uses color for wayfinding, see [Color](?path=/docs/foundatio
 - **Don't remove focus styles.** HDS Core applies a visible focus ring on all interactive elements.
 - **Write descriptive labels.** "Download fiscal year 2025 report" is better than "Download." Supplement short labels with `aria-label` or `aria-describedby` when needed.
 
-The recommended markup shown above includes all necessary ARIA attributes. For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+The recommended markup shown above includes all necessary ARIA attributes. See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS button accessibility tests](https://designsystem.digital.gov/components/button/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/Checkbox.mdx
+++ b/stories/components/Checkbox.mdx
@@ -72,4 +72,4 @@ When a required checkbox group has no selection, an error message appears below 
 
 <Note type="uswds">USWDS recommends avoiding disabled states. Disabled checkboxes have low contrast, don't receive focus, and provide no feedback to screen readers. If you must disable an option, explain why using visible help text and use `aria-disabled="true"` with JavaScript instead of the HTML `disabled` attribute. See the [USWDS disabled state guidance](https://github.com/uswds/uswds/wiki/Disabled-States-Research-Findings-2023) for details.</Note>
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS checkbox accessibility tests](https://designsystem.digital.gov/components/checkbox/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/Form.mdx
+++ b/stories/components/Form.mdx
@@ -170,4 +170,4 @@ Standard USWDS markup places the error message before the input. HDS Core suppor
 - **Keyboard navigation:** users move between fields with Tab and Shift+Tab and activate buttons with Enter or Space.
 - **Known screen reader issues:** VoiceOver on iOS has limited support for fieldset and legend elements. Address this by adding `aria-labelledby` on each input referencing the legend and label IDs. VoiceOver on macOS has partial `aria-describedby` support on text inputs. See [a11ysupport.io](https://a11ysupport.io/tech/aria/aria-describedby_attribute) for current status.
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS form page](https://designsystem.digital.gov/components/form/) for general form accessibility guidance and known issues with screen readers. More specific accessibility tips and common patterns can be found on the [USWDS form templates](https://designsystem.digital.gov/templates/form-templates/) page.

--- a/stories/components/InPageNavigation.mdx
+++ b/stories/components/InPageNavigation.mdx
@@ -71,4 +71,4 @@ Sites can override any property to match their content structure. Set all proper
 - **Focus on activation:** When a keyboard user activates a nav link, focus moves to the target section. When a mouse user clicks, focus stays on the clicked link.
 - Do not skip heading levels in your content (e.g., `h2` to `h4`). The generated nav and screen readers both depend on a logical heading hierarchy.
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS in-page navigation accessibility tests](https://designsystem.digital.gov/components/in-page-navigation/) for component-specific manual testing guidance.

--- a/stories/components/Link.mdx
+++ b/stories/components/Link.mdx
@@ -29,9 +29,7 @@ Add `.usa-link--external` to display a diagonal arrow icon after the link text. 
 Toggle the "Internal escape" control above to see `.hds-link--internal` — an HDS-only escape hatch that suppresses the arrow for NASA subdomains (e.g., `science.nasa.gov`) while keeping any CMS-driven external class intact.
 
 <Note type="uswds">
-  USWDS applies the external arrow automatically when
-  <code>.usa-link--external</code> is present. The HDS external arrow CSS replaces USWDS's built-in external link screen reader labels. Developers <strong>must</strong> add SR text manually:
-  <code>&lt;span class="usa-sr-only"&gt; (external)&lt;/span&gt;</code>
+  USWDS applies the external arrow automatically when <code>.usa-link--external</code> is present. The HDS external arrow CSS replaces USWDS's built-in external link screen reader labels. Developers <strong>must</strong> add SR text manually: <code>&lt;span class="usa-sr-only"&gt; (external)&lt;/span&gt;</code>
 </Note>
 
 ## Links in context
@@ -58,11 +56,7 @@ Links work in headings, body text, and across line breaks. The external arrow sc
 - **Write meaningful link text.** Avoid "click here" or "read more." The link text should make sense out of context (e.g., in a screen reader's links list).
 - **Mark external links consistently.** Any URL that leaves NASA.gov should get `.usa-link--external` unless the destination is a NASA subdomain using `.hds-link--internal`.
 - **Links inherit font size.** No link-specific size classes. Links scale with their parent text.
-- **Never remove the underline.** Because HDS links use body-text color, the dashed underline is the **sole** visual differentiator.
-
-<Note type="figma">
-  The HDS Figma spec shows a dashed underline with a "2, 3" dash pattern. CSS <code>text-decoration</code> doesn't support custom dash patterns, so HDS Core uses <code>dashed</code> as the closest approximation.
-</Note>
+- **Never remove the underline in the default state.** Because HDS links use body-text color, the dashed underline is the **sole** visual differentiator. On focus, the underline is replaced by the full dashed focus ring; the bottom edge of the ring serves the same purpose.
 
 ## Bare link styling (opt-in)
 
@@ -71,21 +65,14 @@ By default, bare `<a>` tags are unstyled. HDS link treatment only applies via `.
 - `$theme-global-link-styles`
 - `$theme-global-content-styles`
 
-<Note type="uswds">This mirrors USWDS's default behavior exactly. Existing USWDS sites migrating to HDS Core keep their existing scoping behavior.</Note>
-
 ## Accessibility
 
 - **External links require screen reader text.** The HDS external arrow is CSS-only and invisible to screen readers. Add SR text manually:
-
   ```html
   <a class="usa-link usa-link--external" href="https://example.com" rel="noreferrer"> Example<span class="usa-sr-only"> (external)</span> </a>
   ```
-
-```
-
 - **Visited links** look the same as unvisited links — intentional to prevent contrast issues across palettes.
 - **Don't remove focus styles.** HDS Core applies a visible focus ring on all interactive elements.
 - **Underline is the affordance.** Removing it breaks accessibility.
 
 The recommended markup shown above includes all necessary attributes. For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
-```

--- a/stories/components/Link.mdx
+++ b/stories/components/Link.mdx
@@ -75,4 +75,4 @@ By default, bare `<a>` tags are unstyled. HDS link treatment only applies via `.
 - **Don't remove focus styles.** HDS Core applies a visible focus ring on all interactive elements.
 - **Underline is the affordance.** Removing it breaks accessibility.
 
-The recommended markup shown above includes all necessary attributes. For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+The recommended markup shown above includes all necessary attributes. See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS link accessibility tests](https://designsystem.digital.gov/components/link/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/List.mdx
+++ b/stories/components/List.mdx
@@ -68,4 +68,4 @@ Use the unstyled variant to remove markers and indentation. Useful for navigatio
   **Differs from USWDS:** HDS ordered lists use CSS counters instead of native markers for numeral styling. Safari VoiceOver won't announce these as lists without `role="list"` — always include it on both `<ul>` and `<ol>`.
 </Note>
 
-See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS list accessibility tests](https://designsystem.digital.gov/components/list/accessibility-tests) for component-specific testing.
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS list accessibility tests](https://designsystem.digital.gov/components/list/accessibility-tests) for component-specific manual testing guidance.

--- a/stories/components/Pagination.mdx
+++ b/stories/components/Pagination.mdx
@@ -101,6 +101,6 @@ The tradeoff: legacy USWDS markup retains the USWDS chevron icons inside the HDS
 - **Arrow labels:** Previous and next buttons have no visible text in numbered variants — each must have `aria-label="Previous page"` or `aria-label="Next page"`.
 - **Icon attributes:** Chevron SVGs inside buttons are decorative — use `aria-hidden="true"`.
 
-The recommended markup shown in the variant examples above includes all necessary ARIA attributes. Previous/next arrows follow the same accessibility patterns as [Icon Button](?path=/docs/components-icon-button-guidance--docs) — see that page's Accessibility section for additional guidance on icon-only interactive elements.
+The recommended markup shown in the variant examples above includes all necessary ARIA attributes. See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS pagination accessibility tests](https://designsystem.digital.gov/components/pagination/accessibility-tests/) for component-specific manual testing guidance.
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+Previous/next arrows follow the same accessibility patterns as [Icon Button](?path=/docs/components-icon-button-guidance--docs); see that page's Accessibility section for additional guidance on icon-only interactive elements.

--- a/stories/components/Prose.mdx
+++ b/stories/components/Prose.mdx
@@ -42,4 +42,4 @@ Inside `.usa-prose`, headings, paragraphs, lists, tables, blockquotes, links, co
 - Ordered lists inside prose retain native list markers for screen reader compatibility. If you need `role="list"` for accessibility (recommended by the HDS accessibility spec), use `.usa-list` markup instead.
 - Links inside prose receive HDS dotted underline styling, which preserves link discoverability for users who don't perceive color.
 
-See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS prose accessibility tests](https://designsystem.digital.gov/components/prose/accessibility-tests) for component-specific testing.
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS prose accessibility tests](https://designsystem.digital.gov/components/prose/accessibility-tests) for component-specific manual testing guidance.

--- a/stories/components/RadioButton.mdx
+++ b/stories/components/RadioButton.mdx
@@ -78,4 +78,4 @@ When a required radio button group has no selection on submit, an error message 
 
 <Note type="uswds">USWDS recommends avoiding disabled states. Disabled radio buttons have low contrast, don't receive focus, and provide no feedback to screen readers. If you must disable an option, explain why using visible help text and use `aria-disabled="true"` with JavaScript instead of the HTML `disabled` attribute. See the [USWDS disabled state guidance](https://github.com/uswds/uswds/wiki/Disabled-States-Research-Findings-2023) for details.</Note>
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS radio button accessibility tests](https://designsystem.digital.gov/components/radio-buttons/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/Select.mdx
+++ b/stories/components/Select.mdx
@@ -91,4 +91,4 @@ Disabled selects prevent interaction. The label dims to match.
 - **Keyboard navigation:** users open the select with Space, Enter, or arrow keys (varies by browser). They navigate options with arrow keys and confirm with Enter.
 - **Don't auto-submit on change.** Changing a select option should not automatically submit a form or navigate to a new page. Users expect to review their selection before submitting.
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS select accessibility tests](https://designsystem.digital.gov/components/select/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/SideNavigation.mdx
+++ b/stories/components/SideNavigation.mdx
@@ -54,3 +54,5 @@ Side navigation is fully supported in HDS Core. Existing USWDS sites using `.usa
 - **Keyboard navigation:** Tabbing moves sequentially through all visible links. Nested sublists displayed via `usa-current` on a parent are part of the tab order. All levels must be reachable without skipping.
 - **Screen reader expectations:** Users expect standard HTML list navigation (`<ul>`, `<li>`) to announce the number of items in the current level.
 - **Contrast:** Active state contrast across all six HDS palettes has been verified via automated Chromatic palette accessibility tests.
+
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS side navigation accessibility tests](https://designsystem.digital.gov/components/side-navigation/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/SiteAlert.mdx
+++ b/stories/components/SiteAlert.mdx
@@ -68,3 +68,5 @@ Use the informational variant for non-urgent announcements: live events, languag
 - Use a heading element (`<h4>`) for the `.usa-alert__heading` when present. The heading level should be appropriate for your page's outline.
 - Tab order proceeds left-to-right through any interactive elements (links, buttons) inside the alert.
 - The recommended markup shown above includes all necessary ARIA attributes.
+
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS site alert accessibility tests](https://designsystem.digital.gov/components/site-alert/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/Table.mdx
+++ b/stories/components/Table.mdx
@@ -93,4 +93,4 @@ Horizontal scroll for tables with many columns.
 - Sortable tables must include an `aria-live="polite"` region immediately after the `<table>` element.
 - Scrollable containers must have `tabindex="0"` for keyboard access.
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS table accessibility tests](https://designsystem.digital.gov/components/table/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/components/Table.stories.js
+++ b/stories/components/Table.stories.js
@@ -738,7 +738,7 @@ export const PaletteA11yHover = {
 
 // --- Focus tests (Chromatic modes + play function) ---
 // Sort button currently inherits the global focus ring from
-// base/_focus.scss (Pattern A, thin, outline). Surface-inverse
+// base/_focus.scss (default treatment, 1px dashed). Surface-inverse
 // focus treatment not yet implemented — see DESIGN.md Table
 // section and _table.scss header comment. This story captures
 // the baseline so Chromatic diffs will show the change when

--- a/stories/components/TextInput.mdx
+++ b/stories/components/TextInput.mdx
@@ -112,4 +112,4 @@ Disabled fields prevent interaction. The label dims to match. Help text remains 
 - **Keyboard navigation:** users move between fields with Tab and Shift+Tab.
 - **Do not use `autocomplete="off"`** unless there is a specific security requirement. Autocomplete helps users complete forms faster and reduces errors.
 
-For general accessibility guidance, see [Accessibility](?path=/docs/foundations-accessibility--docs).
+See [Accessibility](?path=/docs/foundations-accessibility--docs) for HDS-wide guidance and the [USWDS text input accessibility tests](https://designsystem.digital.gov/components/text-input/accessibility-tests/) for component-specific manual testing guidance.

--- a/stories/overview/GettingStarted.mdx
+++ b/stories/overview/GettingStarted.mdx
@@ -2,20 +2,12 @@ import { Meta, Unstyled } from '@storybook/addon-docs/blocks';
 
 <Meta title="Overview/Getting Started" />
 
+{/* prettier-ignore */}
 <Unstyled>
-  <section class="usa-site-alert usa-site-alert--info usa-site-alert--slim margin-bottom-4" aria-label="Site alert">
+  <section class="usa-site-alert usa-site-alert--info usa-site-alert--slim margin-bottom-4" aria-label="Alert">
     <div class="usa-alert">
       <div class="usa-alert__body">
-        <div class="usa-alert__text">
-          <strong>
-            HDS Core is for NASA-branded <code>*.nasa.gov</code> websites only.
-          </strong>{' '}
-          Interagency, non-.gov, and other non-NASA-branded sites should use{' '}
-          <a class="usa-link" href="https://designsystem.digital.gov/">
-            USWDS
-          </a>{' '}
-          instead.
-        </div>
+        <p class="usa-alert__text"><strong>HDS Core is for NASA-branded <code>*.nasa.gov</code> websites only.</strong> Interagency, non-.gov, and other non-NASA-branded sites should use <a class="usa-link" href="https://designsystem.digital.gov/">USWDS</a> instead.</p>
       </div>
     </div>
   </section>
@@ -37,9 +29,7 @@ Sites that can't consolidate may be authorized by the CIO to remain standalone. 
 
 HDS Core also supports **microapps, data visualizations, and interactive embeds** that are served on Flagship CMS sites or enterprise platforms but developed and styled outside the host platform's theme.
 
-{/* 🎨 GRAPHIC OPPORTUNITY: Three-path visual. Columns or minimal flowchart: Archive / Consolidate / Standalone, with HDS Core highlighted on the standalone path and a secondary callout for microapps. Mirrors community meeting structure. */}
-
-{/* COMMENTED OUT: governance for standalone approval is still in flux. Revisit when we have a clear public-facing process to point to. Not sure which path applies to your site? Visit the [Web Toolkit](https://website.nasa.gov) for guidance, or reach out on [GitHub Discussions](https://github.com/nasa/hds-core/discussions). */}
+{/* TODO: Not sure which path applies to your site? Visit the [Web Toolkit](https://website.nasa.gov) (internal NASA link) for guidance, or reach out on [GitHub Discussions](https://github.com/nasa/hds-core/discussions). */}
 
 ## Is HDS Core your path?
 
@@ -52,7 +42,7 @@ HDS Core also supports **microapps, data visualizations, and interactive embeds*
 **You probably need a different path if:**
 
 - Your site's content or functionality could move to a Flagship CMS or another enterprise platform, even if you haven't explored that option yet
-- Your site is being archived or decommissioned
+- Your site is outdated or no longer actively maintained, and is a candidate for archival and decommissioning
 - Your site is not on a `*.nasa.gov` domain
 
 ## Already adopted HDS on your own?
@@ -68,9 +58,9 @@ Two things to consider:
 
 Depending on your site's current state, adopting HDS Core can range from adding a single CSS file to a more involved migration.
 
-- **[Design Standards](?path=/docs/overview-design-standards--docs)** — What every NASA site must achieve visually, whether or not you use HDS Core
-- **[Installation](?path=/docs/overview-installation--docs)** — Technical setup for teams adopting HDS Core
-- **Guides** — Detailed walkthroughs for [existing USWDS sites](?path=/docs/guides-existing-uswds-site-guidance--docs), [React](?path=/docs/guides-react-guidance--docs), [no-build environments](?path=/docs/guides-no-build-environments--docs), and [Sass configuration](?path=/docs/guides-sass-configuration--docs)
+- **[Design Standards](?path=/docs/overview-design-standards--docs)**: What every NASA site must achieve visually, whether or not you use HDS Core
+- **[Installation](?path=/docs/overview-installation--docs)**: Technical setup for teams adopting HDS Core
+- **Guides**: Detailed walkthroughs for [existing USWDS sites](?path=/docs/guides-existing-uswds-site-guidance--docs), [React](?path=/docs/guides-react-guidance--docs), [no-build environments](?path=/docs/guides-no-build-environments--docs), and [Sass configuration](?path=/docs/guides-sass-configuration--docs)
 
 Sites referencing HDS guidance without adopting the package directly will also find the **Foundations** and **Components** sections in the sidebar useful as a design and implementation reference.
 

--- a/tokens.json
+++ b/tokens.json
@@ -1429,7 +1429,7 @@
     "offset": {
       "$type": "dimension",
       "$value": "1px",
-      "$description": "Visual gap between element and ring. Achieved differently per mechanic (SVG mask uses inset:-2px on a sibling pseudo; inline links use outline-offset:1px; checkbox/radio labels use outline-offset:4px to clear the inner box) but the visual result is consistent."
+      "$description": "Visual gap between element and ring. May be achieved differently per mechanic (negative inset, outline-offset, etc.) but the visual result is consistent."
     }
   },
   "layout": {

--- a/tokens.json
+++ b/tokens.json
@@ -1415,19 +1415,22 @@
     }
   },
   "focus": {
+    "$description": "Dashed focus ring for keyboard navigation. Palette-aware via --hds-palette-focus-* custom properties. Used by buttons, links, pagination, icon buttons, accordions, breadcrumbs, table sort, and the global baseline. Solid focus states on form controls (text input border, checkbox/radio inner box) are not tokenized at this time.",
     "width": {
       "$type": "dimension",
-      "$description": "WARNING: Focus ring thickness is pending Creative Director review (Issue #40) and may be consolidated to a single value prior to v1.0.",
-      "thin": {
-        "$value": "1px",
-        "$description": "Currently used by Link, Icon buttons, Checkbox/Radio outer, Pagination, Global baseline."
-      },
-      "thick": {
-        "$value": "2px",
-        "$description": "Currently used by Button (CTA/Secondary/Outline), Primary arrow, Breadcrumb."
-      }
+      "$value": "1px",
+      "$description": "Dashed stroke width. Standardized across all dashed focus rings."
     },
-    "$description": "Under review. Focus ring values may change before 1.0. Do not treat as stable API."
+    "style": {
+      "$type": "strokeStyle",
+      "$value": "dashed",
+      "$description": "All dashed focus rings use a 2,3 dasharray."
+    },
+    "offset": {
+      "$type": "dimension",
+      "$value": "1px",
+      "$description": "Visual gap between element and ring. Achieved differently per mechanic (SVG mask uses inset:-2px on a sibling pseudo; inline links use outline-offset:1px; checkbox/radio labels use outline-offset:4px to clear the inner box) but the visual result is consistent."
+    }
   },
   "layout": {
     "$type": "dimension",


### PR DESCRIPTION
## What this PR does

Refactors the HDS focus ring system from the ground up: new mixin signatures, a unified inline gradient approach (replacing pattern A/B/C nomenclature), inlined SVG masks, and resolved Sass division deprecation warnings. Applies the updated system across all affected components (links, buttons, breadcrumbs, blockquotes, checkboxes, radios, icon buttons, primary arrow). Also ships a custom Storybook footer with per-page GitHub edit links, and hardens the release workflow against spurious releases and changelog shell injection.

Closes #41

## Type of change

- [x] Bug fix (patch)
- [x] New feature or component (minor)
- [x] Breaking change (see Public API section below) -- _pre-v1.0 so breaking changes are still minor semver updates_
- [ ] Documentation only
- [x] Tooling or CI (no effect on published output)

## Checklist

- [x] `npm run format:fix` and `npm run lint:scss:fix` pass
- [x] `npm run lint:js` and `npm run lint:md` pass
- [x] Tested across all 6 palettes in Storybook
- [x] Tested across mobile, tablet, and desktop viewports
- [x] Automated a11y checks pass (`npm test`)
- [x] Storybook documentation updated (if component changed)

## Public API and changesets

- [x] Ran `npm run update:api-snapshot` and reviewed the diff
- [x] Changeset added (`npx changeset`) with appropriate bump level
- [x] Bump level matches the [semver rubric](../CONTRIBUTING.md#semver-rubric)

## Visual review

See Chromatic for before/afters. Latest run: https://www.chromatic.com/build?appId=69c86234709fb66fd7e0b4ab&number=60

## Architecture notes

**Focus ring system:** The gradient-based inline ring approach gives vertical clearance from line-height automatically, per HDS Figma spec — no explicit `padding-block` needed. Horizontal clearance is `padding: 0 4px` / `margin: 0 -4px` to avoid text shift. `--hds-ring` has been removed from the public API surface (inlined); snapshot diff will reflect this.

**Mixin signatures:** `$pseudo` now defaults to `before` — the redundant argument has been dropped from all call sites. If any adopter was calling focus ring mixins directly with explicit `$pseudo` args, this is a minor mixin signature change but not a breaking CSS output change.

**Release workflow (CI-only, no output impact):** Three fixes landed on this branch: quoted `if:` condition to fix YAML anchor parsing, replaced `git describe`-based version detection with `git tag -l` exact-match (eliminates false-positive on repos with no prior tags), and switched `--notes` inline interpolation to `--notes-file` to prevent CHANGELOG CSS content being interpreted as shell commands.

**Bundle size check (CI-only, no output impact):** Corrected limits from binary KiB (×1024) to decimal KB (×1000), matching browser devtools. HDS_MAX raised to 48 KB for v0.8.0 focus ring system (+1.6 KB gzipped). COMBINED_MAX corrected to 96 KB. Measurement method unchanged (raw bytes).

**Storybook footer:** Implemented via `DocsContainer` override — no impact on built CSS output.
