### PR TITLE
fix breaking ReactSetup.mdx by making Note have a default icon if no …

### DIFF
--- a/stories/helpers/Note.jsx
+++ b/stories/helpers/Note.jsx
@@ -13,7 +13,7 @@ const labels = {
 };
 
 export function Note({ type, children }) {
-  const icon = iconConfig[type];
+  const icon = iconConfig[type] ?? iconConfig.code;
   return (
     <div className="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon hds-note" role="note">
       <div className="usa-alert__body">


### PR DESCRIPTION
## What this PR does

Currently there is a bug with the ReactSetup.mdx file. The Note component does not pass in an expected prop, this change makes the Note component robust by defaulting to code icon svg if none passed in, but an alternative solution would be to fix the ReactSetup.mdx component to pass in the prop.
<img width="1868" height="973" alt="Screenshot 2026-06-16 at 11 34 07 AM" src="https://github.com/user-attachments/assets/efd56115-b75f-401d-bf4d-1fde47f72ffc" />

Closes #

## Type of change

<!-- Check one. -->

- [ x] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API section below)
- [ ] Documentation only
- [ ] Tooling or CI (no effect on published output)

## Checklist

<!-- Check all that apply before requesting review. -->

- [x ] `npm run format:fix` and `npm run lint:scss:fix` pass
- [ x] `npm run lint:js` and `npm run lint:md` pass
- [x ] Tested across all 6 palettes in Storybook
- [ x] Tested across mobile, tablet, and desktop viewports
- [ ] Automated a11y checks pass (`npm test`)
- [ ] Storybook documentation updated (if component changed)

## Public API and changesets

<!-- If CI fails the snapshot check, complete these steps. If your PR does not touch `src/scss/**`, skip this section. -->

- [ ] Ran `npm run update:api-snapshot` and reviewed the diff
- [ ] Changeset added (`npx changeset`) with appropriate bump level
- [ ] Bump level matches the [semver rubric](../CONTRIBUTING.md#semver-rubric)

## Visual review

BEFORE
<img width="1868" height="973" alt="Screenshot 2026-06-16 at 11 34 07 AM" src="https://github.com/user-attachments/assets/29a92696-7d1e-46e8-9306-32794bb11567" />

AFTER
<img width="1902" height="998" alt="Screenshot 2026-06-16 at 11 35 44 AM" src="https://github.com/user-attachments/assets/39209584-b86f-4c07-abdd-594fdfc596cf" />


## Notes for reviewers

