### PR TITLE
Disable USWDS type normalization, fix system-wide font sizes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -133,9 +133,9 @@ Three distinct small-text utility classes with unique typography per the HDS Cor
 
 Form labels (`<label>`, `.usa-label`) use Inter 14px semibold — distinct from the typography classes above. See `components/_form.scss`.
 
-### Type Normalization (Known Tech Debt)
+### Type Normalization
 
-All three fonts use the same USWDS cap-height, which disables optical normalization. The Proposal acknowledges this needs future work.
+`$theme-respect-user-font-size: true` disables USWDS cap-height normalization, making `html { font-size: 100% }` the root — declared font sizes match rendered sizes and user browser font-size preferences are respected. All three fonts retain their `364px` cap-height values in `$theme-typeface-tokens` (required for USWDS schema compliance; inert when normalization is off). Measured cap-heights are documented in comments there.
 
 ### Composite Tokens (Deferred to Post-1.0)
 
@@ -428,7 +428,7 @@ All of these match the approved HDS Core Proposal exactly:
 | Line-height values | Exact percentages | Closest USWDS token or raw CSS when delta >10% | USWDS scale too coarse for exact mapping |
 | Overline weight | 400 (normal) | 500 (medium) | Figma consistently uses 500. Pending review. |
 | Overline class name | "Label" | `.hds-overline` | Avoids collision with USWDS `.usa-label`. Industry standard term. |
-| Type normalization | Normalize all three fonts | Deferred | Requires measurement work; noted as tech debt |
+| Type normalization | Normalize all three fonts | Disabled (`$theme-respect-user-font-size: true`) | Measured cap-height analysis found Inter (72.8%) and Public Sans (68.0%) differ by ~7%, producing a 0.76px cap-height delta at 16px. However, USWDS normalization operates on root font-size globally — it cannot equalize per-font rendering without distorting Proposal-specified absolute sizes. Disabling normalization makes declared sizes match rendered sizes, respects user browser font-size preferences (accessibility), and simplifies future responsive type work. Per-font optical adjustments can be targeted overrides if needed. Measured cap-heights retained in theme comments. |
 | TV breakpoint | 1920px | Deferred | USWDS doesn't support it |
 | Checkbox/radio size | 20px (USWDS default) | 18px forced via CSS | Figma specifies 18×18px. USWDS setting can't express 2.25 units. |
 | Checkbox icon | USWDS default glyph | HDS check icon via data URI | Visually distinct from USWDS checkmark |

--- a/src/scss/_hds-uswds-theme.scss
+++ b/src/scss/_hds-uswds-theme.scss
@@ -55,6 +55,7 @@
   $output-these-utilities: (),
   $theme-show-compile-warnings: false,
   $theme-show-notifications: false,
+  $theme-respect-user-font-size: true,
 
   // ----------------------------------------------------------
   // Asset Paths
@@ -237,11 +238,17 @@
   $theme-typeface-tokens: (
     'inter': (
       'display-name': 'Inter',
+      // Normalization disabled — $theme-respect-user-font-size: true
+      // Measured cap-height: 1490/2048 UPM = 72.8%
+      // (0.76px taller caps than Public Sans at 16px)
       'cap-height': 364px,
       'stack': "'Helvetica Neue', Helvetica, Arial, sans-serif",
     ),
     'dm-mono': (
       'display-name': 'DM Mono',
+      // Normalization disabled — $theme-respect-user-font-size: true
+      // Measured cap-height: ~698/1000 UPM = 69.8%
+      // (0.22px taller caps than Public Sans at 16px)
       'cap-height': 364px,
       'stack': "'Consolas', 'Courier', monospace",
     )


### PR DESCRIPTION
## Summary

Closes #46.

- Sets `$theme-respect-user-font-size: true` in `_hds-uswds-theme.scss` so `html { font-size: 100% }` is the root - declared font sizes now match rendered sizes and user browser font-size preferences are respected
- Adds measured cap-height comments to `inter` and `dm-mono` typeface tokens (364px values unchanged; they're inert when normalization is off, kept for USWDS schema compliance)
- Updates `DESIGN.md`: removes "Known Tech Debt" label from the Type Normalization section, rewrites the body to describe the current state, and updates the "What Changed From the Proposal" table row from "Deferred" to "Disabled" with the full rationale

Note: the `_hds-tokens.scss` change from the issue (remove `~` from type scale comments) is no longer needed — the refactored file uses inline `$theme-type-scale-*` settings in `_hds-uswds-theme.scss` without approximation comments.

## Test plan

- [x] Build compiles without Sass errors (`npm run sass:hds`)
- [x] `html { font-size: 100% }` appears in compiled CSS output
- [x] Visual snapshot review in Chromatic — every component story will diff (all font sizes increase to correct Proposal values); accept all diffs in a single batch review to reset the visual baseline
- [x] Spot-check against the post-merge audit checklist in the issue: Button height, Number-lg at mobile, Overline/Label/Caption at 12px, Form inputs, Table cells, Blockquote, Pagination, Accordion