### PR TITLE
docs: complete v1.0 manual accessibility testing

### DIFF
--- a/508.md
+++ b/508.md
@@ -6,23 +6,19 @@ Last updated: 2026-04-02
 
 ## Approach
 
-HDS Core is a CSS/Sass theme layer on [USWDS v3.13.0](https://designsystem.digital.gov/). USWDS publishes its own accessibility conformance report: [USWDS ACR v3.11.0 (May 2025)](https://designsystem.digital.gov/about/accessibility/) using the VPAT 2.5 International Edition format, evaluating 44 components with a combination of automated testing, manual assistive technology testing, and moderated usability studies.
+HDS Core is a CSS/Sass theme layer on [USWDS v3.13.0](https://designsystem.digital.gov/). USWDS publishes its own accessibility conformance report: [USWDS ACR v3.11.0 (May 2025)](https://designsystem.digital.gov/documentation/accessibility/) using the VPAT 2.5 International Edition format, evaluating 44 components with a combination of automated testing, manual assistive technology testing, and moderated usability studies.
 
 HDS Core inherits USWDS's conformance baseline and documents additional testing for what HDS Core changes on top of USWDS:
 
-- **Color palette system** — 6 palettes with custom CSS properties overriding all USWDS colors. Contrast verified via automated axe-core testing across all palette and pseudo-state combinations, plus manual review of non-text elements.
-- **Typography** — Custom font families (Inter, Public Sans, DM Mono), per-element line-heights and letterspacing. Resize behavior verified via 200% browser zoom.
-- **Focus ring** — Two-layer architecture: USWDS theme settings plus palette-aware `:focus-visible` overrides. Visibility verified manually on all six palettes.
-- **Component overrides** — CSS-only overrides on ~18 USWDS components. Markup is unmodified (except `role="list"` on ordered lists for Safari VoiceOver).
-- **Net-new components** — Icon Button and Primary Arrow Button (no USWDS equivalent). Tested independently for keyboard, screen reader, and contrast conformance.
+- **Color palette system**: 6 palettes with custom CSS properties overriding all USWDS colors. Contrast verified via automated axe-core testing across all palette and pseudo-state combinations, plus manual review of non-text elements.
+- **Typography**: Custom font families (Inter, Public Sans, DM Mono), per-element line-heights and letterspacing. Resize behavior verified via 200% browser zoom.
+- **Focus ring**: Two-layer architecture: USWDS theme settings plus palette-aware `:focus-visible` overrides. Visibility verified manually on all six palettes.
+- **Component overrides**: CSS-only overrides on ~18 USWDS components. Markup is unmodified (except `role="list"` on ordered lists for Safari VoiceOver).
+- **Net-new components**: Icon Button and Primary Arrow Button (no USWDS equivalent). Tested independently for keyboard, screen reader, and contrast conformance.
 
-HDS Core v1.0 does not ship several USWDS components that have known accessibility issues in the USWDS ACR (step indicator, range slider, input mask, combo box, time picker, language selector, tooltip, button group, file input, character counter). Where USWDS reported "Partially Supports" due to issues in those components, HDS Core reports "Supports" because those components are not in scope. See the Component Roadmap for Phase 2 plans and the a11y implications of shipping those components in future releases.
+Several USWDS components have known accessibility issues in the USWDS ACR (step indicator, range slider, input mask, combo box, time picker, language selector, tooltip, button group, file input, character counter). Although HDS Core does not style or otherwise touch those default USWDS components, it now ships all USWDS components as is (inc. unstyled ones) for convenience. We thus mirror the USWDS ACR and report "Partially Supports" for the affected USWDS components.
 
 Automated testing: Vitest 4.x runs axe-core (WCAG 2.1 A + AA) on every Storybook story in headless Chromium via Playwright. Palette-aware components have dedicated PaletteA11y stories testing contrast across all six palettes including hover and focus-visible states.
-
-## Manual Testing
-
-Manual testing for v1.0 was tracked in [#33 — v1.0 Manual Accessibility Testing](https://github.com/nasa/hds-core/issues/33). All criteria below reflect the outcome of that testing.
 
 ## WCAG 2.0 Level A
 
@@ -32,10 +28,10 @@ Manual testing for v1.0 was tracked in [#33 — v1.0 Manual Accessibility Testin
 | 1.2.1 | Audio-only and Video-only (Prerecorded) | Not Applicable | HDS Core components do not include audio or video content. |
 | 1.2.2 | Captions (Prerecorded) | Not Applicable | HDS Core components do not include synchronized media. |
 | 1.2.3 | Audio Description or Media Alternative (Prerecorded) | Not Applicable | HDS Core components do not include time-based media. |
-| 1.3.1 | Info and Relationships | Supports | HDS Core components use semantic HTML to convey structure: headings, lists with `role="list"`, tables with `<th scope>`, forms with `<fieldset>`/`<legend>`/`<label>`, and ARIA attributes where required. USWDS reports issues in step indicator (#5294) and range slider (#6116) — neither shipped in HDS Core v1.0. Automated axe-core testing validates structure across all stories. Manual screen reader verification performed for v1.0 baseline. |
-| 1.3.2 | Meaningful Sequence | Supports | DOM reading order matches visual presentation order in all HDS Core components. No CSS reordering (`order`, absolute positioning) is used on meaningful content. USWDS reports a step indicator issue (#5294) — not shipped in HDS Core v1.0. |
+| 1.3.1 | Info and Relationships | Partially Supports | HDS Core components use semantic HTML to convey structure: headings, lists with `role="list"`, tables with `<th scope>`, forms with `<fieldset>`/`<legend>`/`<label>`, and ARIA attributes where required. USWDS reports issues in step indicator (#5294) and range slider (#6116) that are not styled by HDS and thus ship as-is in HDS Core v1.0. Automated axe-core testing validates structure across all stories. Manual screen reader verification performed for v1.0 baseline. |
+| 1.3.2 | Meaningful Sequence | Partially Supports | DOM reading order matches visual presentation order in all HDS Core components. No CSS reordering (`order`, absolute positioning) is used on meaningful content. USWDS reports a step indicator issue (#5294) that is not styled by HDS and thus ships as-is in HDS Core v1.0. |
 | 1.3.3 | Sensory Characteristics | Supports | Instructions for using HDS Core components do not rely solely on shape, size, visual location, or orientation. |
-| 1.4.1 | Use of Color | Supports | HDS Core does not use color as the sole means of conveying information. Error states use red border plus text label. Required fields use asterisk indicator. Links include underline treatment across all six color palettes. Manual review of error states and required field indicators performed for v1.0 baseline. |
+| 1.4.1 | Use of Color | Supports | HDS Core does not use color as the sole means of conveying information. Error states use red border plus text label. Required fields use asterisk indicator. Links include dashed underline treatment across all six color palettes. Manual review of error states and required field indicators performed for v1.0 baseline. |
 | 1.4.2 | Audio Control | Not Applicable | HDS Core components do not include audio content. |
 | 2.1.1 | Keyboard | Supports | All interactive HDS Core components are operable via keyboard. Tier 1 components (accordion, buttons, forms, pagination, table sort, breadcrumb, links) inherit USWDS keyboard behavior via unmodified HTML markup and USWDS JavaScript. Tier 3 components (Icon Button, Primary Arrow Button) use native `<button>` and `<a>` elements — natively keyboard-operable. Manual keyboard testing performed for v1.0 baseline. |
 | 2.1.2 | No Keyboard Trap | Supports | No HDS Core component traps keyboard focus. No modal or focus-trapping components are shipped in v1.0. Users can navigate away from all components using standard Tab/Shift+Tab. Manual keyboard testing performed for v1.0 baseline. |
@@ -48,11 +44,11 @@ Manual testing for v1.0 was tracked in [#33 — v1.0 Manual Accessibility Testin
 | 2.4.4 | Link Purpose (In Context) | Supports | HDS link components use descriptive text. Icon-only interactive elements (Icon Button, Primary Arrow Button) require `aria-label` as documented in component Guidance pages. Automated axe-core testing validates that no empty links or buttons are present. |
 | 3.1.1 | Language of Page | Not Applicable | HDS Core components do not control the `<html lang>` attribute. Language declaration is the responsibility of the consuming application. |
 | 3.2.1 | On Focus | Supports | No HDS Core component initiates a change of context when it receives focus. |
-| 3.2.2 | On Input | Supports | No HDS Core component initiates a change of context on input without prior user instruction. USWDS reports an issue with the language selector — not shipped in HDS Core v1.0. |
-| 3.3.1 | Error Identification | Supports | HDS Core form components identify errors in text using descriptive error messages associated with the input via `aria-describedby`. Error states use text plus visual border (not color alone). USWDS reports an input mask issue (#5481) — not shipped in HDS Core v1.0. Manual verification of form error patterns performed for v1.0 baseline. |
-| 3.3.2 | Labels or Instructions | Supports | All HDS Core form inputs have associated `<label>` elements. Required fields use the USWDS asterisk pattern with `<abbr>` for screen reader announcement. Help text is associated via `aria-describedby`. USWDS reports issues in combo box, search, time picker, and input mask — none shipped in HDS Core v1.0. Manual verification of form labeling performed for v1.0 baseline. |
+| 3.2.2 | On Input | Partially Supports | No HDS Core component initiates a change of context on input without prior user instruction. USWDS reports an issue with the language selector that is not styled by HDS and thus ships as-is in HDS Core v1.0. |
+| 3.3.1 | Error Identification | Partially Supports | HDS Core form components identify errors in text using descriptive error messages associated with the input via `aria-describedby`. Error states use text plus icon (not color alone). USWDS reports an input mask issue (#5481) that is not styled by HDS and thus ships as-is in HDS Core v1.0. Manual verification of form error patterns performed for v1.0 baseline. |
+| 3.3.2 | Labels or Instructions | Partially Supports | All HDS Core form inputs have associated `<label>` elements. Required fields use the USWDS asterisk pattern with `<abbr>` for screen reader announcement. Help text is associated via `aria-describedby`. USWDS reports issues in combo box, search, time picker, and input mask that are not styled by HDS and thus ship as-is in HDS Core v1.0. Manual verification of form labeling performed for v1.0 baseline. |
 | 4.1.1 | Parsing | Supports | Per WCAG 2.0 errata, this criterion is always considered satisfied. HDS Core generates valid HTML verified by automated axe-core testing (checks duplicate IDs, broken ARIA references, nesting errors). |
-| 4.1.2 | Name, Role, Value | Supports | All HDS Core interactive components expose correct name, role, and value to assistive technology. Tier 1 components use standard USWDS HTML markup with semantic elements and ARIA attributes. Tier 3 components (Icon Button, Primary Arrow Button) use native `<button>`/`<a>` elements with `aria-label`. USWDS reports issues in button group, banner, and tooltip — none shipped in HDS Core v1.0. Screen reader testing (VoiceOver) performed for v1.0 baseline. |
+| 4.1.2 | Name, Role, Value | Supports | All HDS Core interactive components expose correct name, role, and value to assistive technology. Tier 1 components use standard USWDS HTML markup with semantic elements and ARIA attributes. Tier 3 components (Icon Button, Primary Arrow Button) use native `<button>`/`<a>` elements with `aria-label`. USWDS reports issues in button group, banner, and tooltip that are not styled by HDS and thus ship as-is in HDS Core v1.0. Screen reader testing (VoiceOver) performed for v1.0 baseline. |
 
 ## WCAG 2.0 Level AA
 
@@ -64,12 +60,12 @@ Manual testing for v1.0 was tracked in [#33 — v1.0 Manual Accessibility Testin
 | 1.4.4 | Resize Text | Supports | HDS Core typography uses the USWDS rem-based token system. Text can be resized up to 200% without loss of content or functionality. Icon button sizing uses px values intentionally (documented in DESIGN.md) but does not clip at 200% zoom. Manual 200% browser zoom testing performed for v1.0 baseline. |
 | 1.4.5 | Images of Text | Not Applicable | HDS Core components do not use images of text. All text is rendered as styled HTML. |
 | 2.4.5 | Multiple Ways | Not Applicable | HDS Core is a component library. Providing multiple ways to locate pages is the responsibility of the consuming application. |
-| 2.4.6 | Headings and Labels | Supports | HDS Core components use descriptive headings and labels. Form labels describe their associated inputs. Accordion headings describe their content sections. USWDS reports breadcrumb research (#6114) — HDS Core uses unmodified USWDS breadcrumb markup with CSS-only overrides. |
-| 2.4.7 | Focus Visible | Supports | All interactive HDS Core components have a visible focus indicator. HDS Core implements a two-layer focus ring: USWDS theme settings plus palette-aware `:focus-visible` styling that ensures visibility across all six color palettes. Manual keyboard testing verified visible focus on every interactive element across all palettes for v1.0 baseline. USWDS reports a file input focus issue — file input not shipped in HDS Core v1.0. |
+| 2.4.6 | Headings and Labels | Supports | HDS Core components use descriptive headings and labels. Form labels describe their associated inputs. Accordion headings describe their content sections. USWDS reports ongoing breadcrumb research (#6114) for enhancements/context; HDS Core uses unmodified USWDS breadcrumb markup with CSS-only overrides. |
+| 2.4.7 | Focus Visible | Partially Supports | All interactive HDS Core components have a visible focus indicator. HDS Core implements a two-layer focus ring: USWDS theme settings plus palette-aware `:focus-visible` styling that ensures visibility across all six color palettes. Manual keyboard testing verified visible focus on every interactive element across all palettes for v1.0 baseline. USWDS reports a file input focus issue (#5616) that is not styled by HDS and thus ships as-is in HDS Core v1.0. |
 | 3.1.2 | Language of Parts | Not Applicable | HDS Core components do not contain content in multiple languages. |
 | 3.2.3 | Consistent Navigation | Not Applicable | HDS Core is a component library. Consistent navigation across pages is the responsibility of the consuming application. |
 | 3.2.4 | Consistent Identification | Supports | HDS Core is a design system — consistent identification is a core purpose. Components with the same function are identified consistently across all instances. Visual presentation, markup patterns, and ARIA attributes are standardized for each component. |
-| 3.3.3 | Error Suggestion | Supports | HDS Core form components support error suggestion patterns through descriptive error message elements associated with inputs. USWDS reports issues with character counter (#5873) and input mask (#5481) — neither shipped in HDS Core v1.0. |
+| 3.3.3 | Error Suggestion | Partially Supports | HDS Core form components support error suggestion patterns through descriptive error message elements associated with inputs. USWDS reports issues with character counter (#5873) and input mask (#5481) that are not styled by HDS and thus ship as-is in HDS Core v1.0. |
 | 3.3.4 | Error Prevention (Legal, Financial, Data) | Not Applicable | HDS Core components do not handle legal commitments, financial transactions, or irreversible data submissions. These safeguards are the responsibility of the consuming application. |
 
 ## Revised Section 508 — Chapter 5: Software
@@ -89,9 +85,9 @@ Manual testing for v1.0 was tracked in [#33 — v1.0 Manual Accessibility Testin
 | 502.3.9 | Modification of Text | Supports | HDS Core does not modify USWDS's text modification capabilities. |
 | 502.3.10 | List of Actions | Supports | HDS styled lists and interactive components expose available actions to assistive technology via standard HTML semantics. |
 | 502.3.11 | Actions on Objects | Supports | HDS Core does not modify USWDS's programmatic action execution. All interactive behaviors (accordion expand/collapse, table sort, pagination) use USWDS JavaScript. |
-| 502.3.12 | Focus Cursor | Supports | USWDS reports a file input focus issue — not shipped in HDS Core v1.0. HDS Core's palette-aware focus ring architecture maintains visible focus tracking across all six palettes. Focus information remains programmatically determinable. |
+| 502.3.12 | Focus Cursor | Partially Supports | USWDS reports a file input focus issue that is not styled by HDS and thus ships as-is in HDS Core v1.0. HDS Core's palette-aware focus ring architecture maintains visible focus tracking across all six palettes. Focus information remains programmatically determinable. |
 | 502.3.13 | Modification of Focus Cursor | Supports | HDS Core does not modify USWDS's focus attribute handling. Focus and selection attributes can be set programmatically by assistive technology. |
-| 502.3.14 | Event Notification | Supports | USWDS reports issues in button group, banner, and tooltip — none shipped in HDS Core v1.0. All shipped components provide change notifications to assistive technology via unmodified USWDS JavaScript. |
+| 502.3.14 | Event Notification | Partially Supports | USWDS reports issues in button group, banner, and tooltip that are not styled by HDS and thus ship as-is in HDS Core v1.0. All HDS Core-styled components provide change notifications to assistive technology via unmodified USWDS JavaScript. |
 | 502.4 | Platform Accessibility Features | Supports | HDS Core is delivered as CSS/Sass. It does not interact with platform accessibility APIs directly — the browser and USWDS JavaScript handle platform integration. No platform features are overridden or suppressed. |
 | 503.2 | User Preferences | Not Applicable | HDS Core is a CSS theme layer, not an application. |
 | 503.3 | Alternative User Interfaces | Not Applicable | HDS Core does not provide alternative user interfaces. |
@@ -136,8 +132,8 @@ This section is informational and not required for the release process.
 | 1.4.10 | Reflow | Not yet evaluated | HDS Core components use responsive USWDS grid and relative units. No horizontal scrolling observed at 320px viewport width during 200% zoom testing, but a dedicated reflow audit has not been performed. |
 | 1.4.11 | Non-text Contrast | Partially evaluated | Non-text contrast ratios for list markers, table sort icons, accordion chevrons, external link arrows, link underlines, checkbox icons, and icon button glyphs are documented and verified in DESIGN.md. Icon button utility circle strokes are decorative framing — the icon glyph and contextual placement provide the primary interactive affordance (see DESIGN.md for rationale). axe-core cannot inspect pseudo-elements or CSS-generated content. |
 | 1.4.12 | Text Spacing | Not yet evaluated | HDS Core typography uses USWDS rem-based tokens. No `!important` overrides prevent user text spacing adjustments. A dedicated text spacing override test has not been performed. |
-| 1.4.13 | Content on Hover or Focus | Supports | HDS Core does not display additional content on hover or focus that obscures other content. Hover states change existing element styling (underline style, background color) but do not reveal new content. No tooltips or popovers are shipped in v1.0. |
-| 4.1.3 | Status Messages | Not Applicable | HDS Core v1.0 components do not generate status messages. Form error messages are present in the DOM at render time (not dynamically injected). Accordion expand/collapse uses USWDS JavaScript with `aria-expanded` — state change, not a status message. |
+| 1.4.13 | Content on Hover or Focus | Supports | HDS Core does not display additional content on hover or focus that obscures other content. Hover states change existing element styling (underline style, background color) but do not reveal new content. No tooltips or popovers are styled by HDS Core in v1.0. |
+| 4.1.3 | Status Messages | Not Applicable | HDS Core v1.0 components do not generate status messages. Form error messages are present in the DOM at render time (not dynamically injected). Accordion expand/collapse uses USWDS JavaScript with `aria-expanded` as a state change, not a status message. |
 
 ## Testing Methodology
 
@@ -166,7 +162,7 @@ Conformance was evaluated using the following methods:
 
 **Upstream conformance:**
 
-- USWDS v3.13.0 — see [USWDS ACR v3.11.0 (May 2025)](https://designsystem.digital.gov/about/accessibility/) for upstream evaluation covering 44 components using ANDI, pa11y, VoiceOver, NVDA, JAWS, and moderated usability studies with 13 participants
+- USWDS v3.13.0 — see [USWDS ACR v3.11.0 (May 2025)](https://designsystem.digital.gov/documentation/accessibility/) for upstream evaluation covering 44 components using ANDI, pa11y, VoiceOver, NVDA, JAWS, and moderated usability studies with 13 participants
 
 **Tools:**
 
@@ -177,7 +173,7 @@ Conformance was evaluated using the following methods:
 
 **Scope:**
 
-- HDS Core v1.0 component inventory: Accordion, Breadcrumb, Button (CTA/Secondary/Outline/Unstyled), Checkbox, Chip (CSS-only), Form (composed), Icon Button, In-Page Navigation, Intro Text, Link, List, Pagination, Primary Arrow Button, Prose, Radio Button, Select, Site Alert, Table, Tag, Text Input
+- HDS Core v1.0 component inventory: Accordion, Breadcrumb, Button (CTA/Secondary/Outline/Unstyled), Checkbox, Chip (CSS-only), Form (composed), Icon Button, In-Page Navigation, Intro Text, Link, List, Pagination, Primary Arrow Button, Prose, Radio Button, Select, Side Navigation, Site Alert, Table, Tag, Text Input
 - Evaluation date: 2026-06-30
 - Evaluators: Abby Bowman (@abbybowman), Justin Peacock (@justin-peacock)
 

--- a/508.md
+++ b/508.md
@@ -20,9 +20,9 @@ HDS Core v1.0 does not ship several USWDS components that have known accessibili
 
 Automated testing: Vitest 4.x runs axe-core (WCAG 2.1 A + AA) on every Storybook story in headless Chromium via Playwright. Palette-aware components have dedicated PaletteA11y stories testing contrast across all six palettes including hover and focus-visible states.
 
-## Pending Manual Verification
+## Manual Testing
 
-Criteria in the tables below that are prefixed with **⚠️ Pending manual verification** have draft answers based on automated testing and USWDS inheritance, but require manual testing to finalize. See [#33 — v1.0 Manual Accessibility Testing](https://github.com/nasa/hds-core/issues/33) for the detailed checklist and progress. When that issue is closed, all prefixes in this document will have been removed and the answers are ready to submit.
+Manual testing for v1.0 was tracked in [#33 — v1.0 Manual Accessibility Testing](https://github.com/nasa/hds-core/issues/33). All criteria below reflect the outcome of that testing.
 
 ## WCAG 2.0 Level A
 
@@ -32,10 +32,10 @@ Criteria in the tables below that are prefixed with **⚠️ Pending manual veri
 | 1.2.1 | Audio-only and Video-only (Prerecorded) | Not Applicable | HDS Core components do not include audio or video content. |
 | 1.2.2 | Captions (Prerecorded) | Not Applicable | HDS Core components do not include synchronized media. |
 | 1.2.3 | Audio Description or Media Alternative (Prerecorded) | Not Applicable | HDS Core components do not include time-based media. |
-| 1.3.1 | Info and Relationships | Supports | ⚠️ Pending manual verification — HDS Core components use semantic HTML to convey structure: headings, lists with `role="list"`, tables with `<th scope>`, forms with `<fieldset>`/`<legend>`/`<label>`, and ARIA attributes where required. USWDS reports issues in step indicator (#5294) and range slider (#6116) — neither shipped in HDS Core v1.0. Automated axe-core testing validates structure across all stories. Manual screen reader verification performed for v1.0 baseline. |
+| 1.3.1 | Info and Relationships | Supports | HDS Core components use semantic HTML to convey structure: headings, lists with `role="list"`, tables with `<th scope>`, forms with `<fieldset>`/`<legend>`/`<label>`, and ARIA attributes where required. USWDS reports issues in step indicator (#5294) and range slider (#6116) — neither shipped in HDS Core v1.0. Automated axe-core testing validates structure across all stories. Manual screen reader verification performed for v1.0 baseline. |
 | 1.3.2 | Meaningful Sequence | Supports | DOM reading order matches visual presentation order in all HDS Core components. No CSS reordering (`order`, absolute positioning) is used on meaningful content. USWDS reports a step indicator issue (#5294) — not shipped in HDS Core v1.0. |
 | 1.3.3 | Sensory Characteristics | Supports | Instructions for using HDS Core components do not rely solely on shape, size, visual location, or orientation. |
-| 1.4.1 | Use of Color | Supports | ⚠️ Pending manual verification — HDS Core does not use color as the sole means of conveying information. Error states use red border plus text label. Required fields use asterisk indicator. Links include underline treatment across all six color palettes. Manual review of error states and required field indicators performed for v1.0 baseline. |
+| 1.4.1 | Use of Color | Supports | HDS Core does not use color as the sole means of conveying information. Error states use red border plus text label. Required fields use asterisk indicator. Links include underline treatment across all six color palettes. Manual review of error states and required field indicators performed for v1.0 baseline. |
 | 1.4.2 | Audio Control | Not Applicable | HDS Core components do not include audio content. |
 | 2.1.1 | Keyboard | Supports | All interactive HDS Core components are operable via keyboard. Tier 1 components (accordion, buttons, forms, pagination, table sort, breadcrumb, links) inherit USWDS keyboard behavior via unmodified HTML markup and USWDS JavaScript. Tier 3 components (Icon Button, Primary Arrow Button) use native `<button>` and `<a>` elements — natively keyboard-operable. Manual keyboard testing performed for v1.0 baseline. |
 | 2.1.2 | No Keyboard Trap | Supports | No HDS Core component traps keyboard focus. No modal or focus-trapping components are shipped in v1.0. Users can navigate away from all components using standard Tab/Shift+Tab. Manual keyboard testing performed for v1.0 baseline. |
@@ -49,10 +49,10 @@ Criteria in the tables below that are prefixed with **⚠️ Pending manual veri
 | 3.1.1 | Language of Page | Not Applicable | HDS Core components do not control the `<html lang>` attribute. Language declaration is the responsibility of the consuming application. |
 | 3.2.1 | On Focus | Supports | No HDS Core component initiates a change of context when it receives focus. |
 | 3.2.2 | On Input | Supports | No HDS Core component initiates a change of context on input without prior user instruction. USWDS reports an issue with the language selector — not shipped in HDS Core v1.0. |
-| 3.3.1 | Error Identification | Supports | ⚠️ Pending manual verification — HDS Core form components identify errors in text using descriptive error messages associated with the input via `aria-describedby`. Error states use text plus visual border (not color alone). USWDS reports an input mask issue (#5481) — not shipped in HDS Core v1.0. Manual verification of form error patterns performed for v1.0 baseline. |
-| 3.3.2 | Labels or Instructions | Supports | ⚠️ Pending manual verification — All HDS Core form inputs have associated `<label>` elements. Required fields use the USWDS asterisk pattern with `<abbr>` for screen reader announcement. Help text is associated via `aria-describedby`. USWDS reports issues in combo box, search, time picker, and input mask — none shipped in HDS Core v1.0. Manual verification of form labeling performed for v1.0 baseline. |
+| 3.3.1 | Error Identification | Supports | HDS Core form components identify errors in text using descriptive error messages associated with the input via `aria-describedby`. Error states use text plus visual border (not color alone). USWDS reports an input mask issue (#5481) — not shipped in HDS Core v1.0. Manual verification of form error patterns performed for v1.0 baseline. |
+| 3.3.2 | Labels or Instructions | Supports | All HDS Core form inputs have associated `<label>` elements. Required fields use the USWDS asterisk pattern with `<abbr>` for screen reader announcement. Help text is associated via `aria-describedby`. USWDS reports issues in combo box, search, time picker, and input mask — none shipped in HDS Core v1.0. Manual verification of form labeling performed for v1.0 baseline. |
 | 4.1.1 | Parsing | Supports | Per WCAG 2.0 errata, this criterion is always considered satisfied. HDS Core generates valid HTML verified by automated axe-core testing (checks duplicate IDs, broken ARIA references, nesting errors). |
-| 4.1.2 | Name, Role, Value | Supports | ⚠️ Pending manual verification — All HDS Core interactive components expose correct name, role, and value to assistive technology. Tier 1 components use standard USWDS HTML markup with semantic elements and ARIA attributes. Tier 3 components (Icon Button, Primary Arrow Button) use native `<button>`/`<a>` elements with `aria-label`. USWDS reports issues in button group, banner, and tooltip — none shipped in HDS Core v1.0. Screen reader testing (VoiceOver) performed for v1.0 baseline. |
+| 4.1.2 | Name, Role, Value | Supports | All HDS Core interactive components expose correct name, role, and value to assistive technology. Tier 1 components use standard USWDS HTML markup with semantic elements and ARIA attributes. Tier 3 components (Icon Button, Primary Arrow Button) use native `<button>`/`<a>` elements with `aria-label`. USWDS reports issues in button group, banner, and tooltip — none shipped in HDS Core v1.0. Screen reader testing (VoiceOver) performed for v1.0 baseline. |
 
 ## WCAG 2.0 Level AA
 
@@ -60,7 +60,7 @@ Criteria in the tables below that are prefixed with **⚠️ Pending manual veri
 | --- | --- | --- | --- |
 | 1.2.4 | Captions (Live) | Not Applicable | HDS Core components do not include live audio in synchronized media. |
 | 1.2.5 | Audio Description (Prerecorded) | Not Applicable | HDS Core components do not include synchronized media. |
-| 1.4.3 | Contrast (Minimum) | Supports | ⚠️ Pending manual verification — HDS Core maintains minimum 4.5:1 contrast ratio for normal text and 3:1 for large text across all six color palettes (white, light, midtone, dark, blue, black). Automated axe-core contrast testing runs on every component story plus dedicated PaletteA11y stories testing all palette and pseudo-state combinations (default, hover, focus-visible). Manual verification of text contrast performed for v1.0 baseline. |
+| 1.4.3 | Contrast (Minimum) | Supports | HDS Core maintains minimum 4.5:1 contrast ratio for normal text and 3:1 for large text across all six color palettes (white, light, midtone, dark, blue, black). Automated axe-core contrast testing runs on every component story plus dedicated PaletteA11y stories testing all palette and pseudo-state combinations (default, hover, focus-visible). Manual verification of text contrast performed for v1.0 baseline. |
 | 1.4.4 | Resize Text | Supports | HDS Core typography uses the USWDS rem-based token system. Text can be resized up to 200% without loss of content or functionality. Icon button sizing uses px values intentionally (documented in DESIGN.md) but does not clip at 200% zoom. Manual 200% browser zoom testing performed for v1.0 baseline. |
 | 1.4.5 | Images of Text | Not Applicable | HDS Core components do not use images of text. All text is rendered as styled HTML. |
 | 2.4.5 | Multiple Ways | Not Applicable | HDS Core is a component library. Providing multiple ways to locate pages is the responsibility of the consuming application. |
@@ -178,8 +178,8 @@ Conformance was evaluated using the following methods:
 **Scope:**
 
 - HDS Core v1.0 component inventory: Accordion, Breadcrumb, Button (CTA/Secondary/Outline/Unstyled), Checkbox, Chip (CSS-only), Form (composed), Icon Button, In-Page Navigation, Intro Text, Link, List, Pagination, Primary Arrow Button, Prose, Radio Button, Select, Site Alert, Table, Tag, Text Input
-- Evaluation date: TBA
-- Evaluator: Abby Bowman (@abbybowman)
+- Evaluation date: 2026-06-30
+- Evaluators: Abby Bowman (@abbybowman), Justin Peacock (@justin-peacock)
 
 ## Appendix: Color Contrast Reference
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -217,9 +217,35 @@ HDS outline buttons on dark backgrounds keep the **NASA Blue** border (not monot
 
 **Original HDS:** Multi-color SVGs (e.g., blue circle with white icon baked in). **HDS Core:** Two layers: single-color SVG glyph (`currentColor`) + CSS-styled circle container. All roles — including interactive — use sprite glyphs with `currentColor`. CSS handles color changes for palettes, hover states, and `aria-expanded` toggling. No standalone SVG files are needed.
 
-### Utility Circle Stroke Contrast
+### Non-Text Contrast: Utility Circle (WCAG 2.1 § 1.4.11)
 
-Utility circle strokes are decorative framing — the icon glyph and contextual placement (accordion chevron, pagination arrow, media control, toolbar action) provide the primary affordance for identifying the interactive element. Icon glyph contrast against its background must meet WCAG 1.4.11 (3:1). Circle stroke contrast is not required under 1.4.11 because the stroke is not the visual information "required to identify" the component. See `base/_palettes.scss` for per-palette token values.
+**Glyph contrast** (`--hds-palette-utility-icon` vs `--hds-palette-utility-fill`):
+
+| Palette | Icon                   | Circle fill            | Ratio   |
+| ------- | ---------------------- | ---------------------- | ------- |
+| White   | Carbon Black `#000000` | White `#ffffff`        | 21:1 💎 |
+| Light   | Carbon Black `#000000` | White `#ffffff`        | 21:1 💎 |
+| Midtone | Carbon Black `#000000` | White `#ffffff`        | 21:1 💎 |
+| Dark    | White `#ffffff`        | Carbon Black `#000000` | 21:1 💎 |
+| Blue    | White `#ffffff`        | Carbon Black `#000000` | 21:1 💎 |
+| Black   | White `#ffffff`        | Carbon Black `#000000` | 21:1 💎 |
+
+Hover state (`--hds-palette-utility-icon` vs `--hds-palette-utility-hover-fill`):
+
+| Palette | Icon                   | Hover fill             | Ratio     |
+| ------- | ---------------------- | ---------------------- | --------- |
+| White   | Carbon Black `#000000` | Carbon 05 `#f6f6f6`    | 19.4:1 💎 |
+| Light   | Carbon Black `#000000` | Carbon 05 `#f6f6f6`    | 19.4:1 💎 |
+| Midtone | Carbon Black `#000000` | Carbon 05 `#f6f6f6`    | 19.4:1 💎 |
+| Dark    | White `#ffffff`        | Carbon Black `#000000` | 21:1 💎   |
+| Blue    | White `#ffffff`        | Carbon Black `#000000` | 21:1 💎   |
+| Black   | White `#ffffff`        | Carbon Black `#000000` | 21:1 💎   |
+
+**Stroke contrast** (`--hds-palette-utility-stroke` vs palette background) — exempt as decorative:
+
+Utility circle strokes are decorative framing — the icon glyph and contextual placement (accordion chevron, pagination arrow, media control, toolbar action) provide the primary affordance for identifying the interactive element. Icon glyph contrast against its background must meet WCAG 1.4.11 (3:1). Circle stroke contrast is not required under 1.4.11 because the stroke is not the visual information "required to identify" the component.
+
+Default stroke fails on all 6 palettes (C-20 / C-40 / C-60 vs White / C-05 / C-20 / C-90 / Blue Shade / Black — 1.38:1 to 2.96:1). Hover stroke (`--hds-palette-utility-hover-stroke`): light palettes use C-40 (1.95:1–2.98:1, fail); dark/blue/black palettes use C-05 (9.29:1–19.4:1 💎). All exempt as decorative framing. See `base/_palettes.scss` for per-palette token values.
 
 ### Interactive Icon Button
 
@@ -278,12 +304,26 @@ HTML `<caption>` = HDS Figma "Title" + optional "Subtitle." It is the semantic a
 
 USWDS JS injects a `<button>` with inline SVG arrows into each `th[data-sortable]`. HDS replaces the arrows visually with filled triangle icons via CSS mask-image — same technique as the accordion chevron. The USWDS SVG stays in the DOM for High Contrast Mode fallback. See `components/_table.scss`.
 
+### Non-Text Contrast: Sort Icons (WCAG 2.1 § 1.4.11)
+
+Sort triangles use CSS `mask-image` on the injected USWDS `<button>`. The icon `background-color` is measured against the `<th>` header background at the moment the icon is visible.
+
+| State                                       | Icon                | Header background              | Ratio       |
+| ------------------------------------------- | ------------------- | ------------------------------ | ----------- |
+| Sorted ascending / descending — light table | NASA Blue `#1c67e3` | Carbon 10 `#e3e3e3`            | 3.99:1 ⚠️ ✓ |
+| Sorted ascending / descending — dark table  | Blue Tint `#288bff` | Carbon 80 `#2e2e32`            | 4.00:1 ⚠️ ✓ |
+| Unsorted hover / focus-within — light table | Carbon 40 `#959599` | Carbon 05 `#f6f6f6` (hover bg) | 2.76:1 ❌   |
+| Unsorted hover / focus-within — dark table  | Carbon 40 `#959599` | Carbon 70 `#444447` (hover bg) | 3.25:1 ⚠️ ✓ |
+
+The unsorted icon is transparent by default; it only becomes visible on hover/focus. The light-table unsorted-hover pair (2.76:1) fails WCAG 2.1 § 1.4.11 (3:1 non-text minimum). WCAG 2.1 is beyond the required WCAG 2.0 scope for this release. The sort affordance on unsorted columns is also communicated by pointer-cursor styling on the header. Deferred to Phase 2 for a colour fix.
+
 ### Deferred to Phase 2
 
 - Mobile text sizing, mobile stacked variants
 - Midtone palette sorted column colors
 - Advanced features (tabs, actions bar, filter panel, search, download, print, accordion mobile layout, fixed first column).
 - Surface-inverse focus ring (Figma specifies ring color inverse of component fill for table cells — not yet implemented, currently inherits global focus ring)
+- Unsorted-hover sort icon on light table: Carbon 40 on Carbon 05 = 2.76:1, fails WCAG 2.1 § 1.4.11
 
 ## List
 
@@ -363,6 +403,23 @@ See `components/_site-alert.scss` for implementation.
 - **Hover State:** Not specified in Figma. Currently unimplemented — pending research on full-row hover patterns.
 
 See `components/_accordion.scss` for implementation.
+
+### Non-Text Contrast: Chevron Icon (WCAG 2.1 § 1.4.11)
+
+The accordion's `::after` pseudo-element uses `mask-image` to render the chevron glyph: `background-color` is set to `--hds-palette-utility-icon` and masked to the chevron SVG shape (12px at 16px base). The circle stroke (`--hds-palette-utility-stroke`) is decorative framing — exempt from WCAG 1.4.11 on the same basis as icon button utility circle strokes. See Icon Button § Utility Circle Stroke Contrast.
+
+Chevron glyph (`--hds-palette-utility-icon`) vs palette background (`--hds-palette-bg`):
+
+| Palette | Glyph                  | Background                | Ratio     |
+| ------- | ---------------------- | ------------------------- | --------- |
+| White   | Carbon Black `#000000` | Spacesuit White `#ffffff` | 21:1 💎   |
+| Light   | Carbon Black `#000000` | Carbon 05 `#f6f6f6`       | 19.4:1 💎 |
+| Midtone | Carbon Black `#000000` | Carbon 20 `#d1d1d1`       | 13.7:1 💎 |
+| Dark    | White `#ffffff`        | Carbon 90 `#17171b`       | 17.8:1 💎 |
+| Blue    | White `#ffffff`        | Blue Shade `#0b3d91`      | 10.0:1 💎 |
+| Black   | White `#ffffff`        | Carbon Black `#000000`    | 21:1 💎   |
+
+Circle stroke (`--hds-palette-utility-stroke`) vs palette background: C-20 to C-60 vs White/C-05/C-20/C-90/Blue Shade/Black — all fail 3:1 (1.38:1 to 2.96:1). Exempt as decorative framing.
 
 ## Blockquote
 


### PR DESCRIPTION
## Summary

- Documents verified WCAG 2.1 §1.4.11 non-text contrast ratios for the three remaining unchecked items in #33: accordion chevron, table sort icons, and icon button utility circle
- Removes all `⚠️ Pending manual verification` prefixes from `508.md` now that manual testing is complete; updates evaluation date and adds co-evaluator
- Surfaces one Phase 2 deferred finding: unsorted-hover sort icon on light table (C-40 on C-05 = 2.76:1, fails WCAG 2.1 §1.4.11 — beyond required WCAG 2.0 scope)

## Changes

**`DESIGN.md`** - three new contrast ratio subsections:
- Accordion § Non-Text Contrast: Chevron Icon — glyph passes on all 6 palettes (10:1–21:1 💎); circle stroke exempt as decorative
- Table § Non-Text Contrast: Sort Icons — sorted states pass (3.99:1 / 4.00:1 ⚠️ ✓); unsorted hover on light table fails (2.76:1), deferred to Phase 2
- Icon Button § Non-Text Contrast: Utility Circle — glyph is 21:1 💎 on all palettes default and hover; stroke exempt as decorative

**`508.md`**:
- Renamed section "Pending Manual Verification" → "Manual Testing"
- Removed `⚠️ Pending manual verification —` prefix from criteria 1.3.1, 1.4.1, 1.4.3, 3.3.1, 3.3.2, 4.1.2
- Evaluation date: 2026-06-30; added Justin Peacock (@justin-peacock) as co-evaluator

## Test plan

- [x] `npm run lint:md` passes (documentation-only change)
- [x] `npm run format` passes
- [x] Verify contrast ratios in DESIGN.md against the 508.md Appendix color contrast matrix
- [x] Confirm #33 checklist is fully checked before merging and close the issue