### PR TITLE
docs: finalize CC0 1.0 license text from OGC and update references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ HDS Core is NASA's design system for public-facing websites on `*.nasa.gov` doma
 
 Whether you're fixing a typo, reporting a browser bug, proposing a new component pattern, or improving accessibility, your contribution helps make NASA's web presence better for the public. We want to make the contribution process as clear and low-friction as possible.
 
+All contributions are released into the public domain under [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/); see [Licensing of contributions](#licensing-of-contributions) for details.
+
 ## Scope
 
 HDS Core covers the CSS/Sass implementation of NASA's Horizon Design System on USWDS. Some things fall outside this repo's scope:
@@ -228,6 +230,14 @@ Maintainers may:
 - Ask for additional context or testing
 
 Design changes that affect NASA's visual identity may involve additional review to ensure alignment with agency brand standards.
+
+## Licensing of contributions
+
+HDS Core is released into the worldwide public domain under the [CC0 1.0 Universal Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+By submitting a contribution — code, documentation, or any other material — you agree that your contribution is released under CC0 1.0 alongside the rest of the project. You are dedicating it to the public domain and waiving all copyright and related rights, worldwide, to the fullest extent permitted by law.
+
+Only contribute work you have the right to dedicate this way. Don't submit code, fonts, images, or other assets that are owned by someone else or licensed under terms incompatible with CC0. Bundled third-party assets (such as the Inter and DM Mono fonts under the SIL Open Font License) are the exception and are tracked separately in [LICENSE.md](LICENSE.md).
 
 ## Code of Conduct
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -4,11 +4,11 @@ HDS Core exists because of the work of many people across NASA and the open-sour
 
 ## HDS Core
 
-HDS Core was developed within NASA's Office of the Chief Information Officer (OCIO). The HDS Core Proposal — which defined the standardization and technical mapping of the HDS visual specification to the USWDS framework — was co-authored by a NASA designer and a contractor developer in 2024.
+HDS Core was developed within NASA's Office of the Chief Information Officer (OCIO). The HDS Core Proposal, which defined the standardization and technical mapping of the HDS visual specification to the USWDS framework, was co-authored by a NASA designer (@courtbee) and a contractor developer (@marktimemedia) in 2024.
 
 ## Horizon Design System
 
-The Horizon Design System visual specification — the comprehensive set of brand standards, component guidelines, and design patterns that HDS Core implements — was created by [Blink UX](https://blinkux.com/) under contract to NASA, 2021–2022. All HDS deliverables are fully NASA-owned.
+The Horizon Design System visual specification, the comprehensive set of brand standards, component guidelines, and design patterns that HDS Core implements, was created by [Blink UX](https://blinkux.com/) under contract to NASA, 2021–2022. All HDS deliverables are fully NASA-owned.
 
 ## Built On
 
@@ -22,4 +22,4 @@ HDS Core is built on the [U.S. Web Design System (USWDS)](https://designsystem.d
 
 ### Development Tools
 
-HDS Core's development environment uses open-source tools including [Storybook](https://storybook.js.org/), [Gulp](https://gulpjs.com/), [Vite](https://vite.dev/), [Vitest](https://vitest.dev/), [Playwright](https://playwright.dev/), and [Prettier](https://prettier.io/). These tools are not included in the HDS Core distribution.
+HDS Core's development environment uses open-source tools including [Storybook](https://storybook.js.org/), [Vite](https://vite.dev/), [Vitest](https://vitest.dev/), [Playwright](https://playwright.dev/), and [Prettier](https://prettier.io/). These development tools are not included in the HDS Core distribution.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,46 +1,34 @@
-# License
+# HDS Core
 
-## HDS Core
+## Licenses and Attribution
 
-Copyright © 2024 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
+A few parts of this project are not in the public domain. Attribution and licensing information for those parts are described in detail in the license details below.
 
-License determination pending — this software is undergoing the NASA software release process. The applicable open-source license will be added here upon completion of the release review.
+The rest of this project is in the worldwide public domain, released under the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
 
-## Third-Party Software
+## Contributing
 
-HDS Core includes the following third-party software, each subject to its own license terms. These licenses apply only to the specific components listed below, not to HDS Core as a whole.
+All [contributions](CONTRIBUTING.md) to this project will be released under the CC0 dedication alongside the public domain portions of this project.
 
-### Inter
+# LICENSE
 
-Inter is a typeface designed by Rasmus Andersson.
+As a work of the United States Government, the software is not subject to copyright protection within the United States. NASA waives copyright and related rights in this software worldwide through the CC0 1.0 Universal Public Domain Dedication (<https://creativecommons.org/publicdomain/zero/1.0/>).
 
-- License: SIL Open Font License 1.1
-- Source: <https://github.com/rsms/inter>
-- Full license: <https://github.com/rsms/inter/blob/master/LICENSE.txt>
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
 
-SIL Open Font License 1.1 — Summary of key terms:
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author.
 
-- The font may be used, modified, and redistributed freely.
-- The font may not be sold by itself — only as part of a larger software package (which applies to HDS Core).
-- Modified versions may not use the "Inter" reserved font name.
-- This license notice must be included in all copies or substantial portions of the font.
+The following third-party assets are included in the distributed package as font files and licensed under the [SIL Open Font License, Version 1.1](https://openfontlicense.org/open-font-license-official-text/):
 
-### DM Mono
+- Inter (typeface) version 3.019 - <https://rsms.me/inter>
+- DM Mono (typeface) version 1.000 - <https://github.com/googlefonts/dm-mono>
 
-DM Mono is a typeface designed by Colophon Foundry for Google.
+The SIL Open Font License requires that the license notice be included with any distribution and that the fonts not be sold by themselves (only as part of a larger software package).
 
-- License: SIL Open Font License 1.1
-- Source: <https://github.com/googlefonts/dm-mono>
-- Full license: <https://github.com/googlefonts/dm-mono/blob/main/OFL.txt>
+## Trademark, Logos, Identifiers
 
-The same SIL Open Font License 1.1 terms described above for Inter apply to DM Mono.
+NASA owns, reserves, and retains all rights, title, and interest in all trademarks owned by NASA. The User does not acquire any right or interest of any kind in any NASA trademark because of their use of this work.
 
-## Peer Dependencies (Not Included)
+The NASA Insignia, Logotype, identifiers, and imagery are not in the public domain. The use of the Insignia, Logotype and NASA identifiers is protected by law, and imagery is made available for use consistent with Media Usage Guidelines. The NASA Graphics Standards Manual was issued under the authority of [14 Code of Federal Regulations (CFR) 1221](https://www.ecfr.gov/current/title-14/chapter-V/part-1221).
 
-HDS Core is built on the U.S. Web Design System (USWDS), which is a peer dependency installed separately by consuming projects. USWDS is not included in the HDS Core distribution.
-
-- USWDS License: CC0 1.0 Universal (Public Domain Dedication)
-- Source: <https://github.com/uswds/uswds>
-- Full license: <https://github.com/uswds/uswds/blob/develop/LICENSE.md>
-
-USWDS includes the Public Sans typeface (CC0 1.0, Public Domain), which HDS Core uses as its body font. Public Sans is provided by USWDS, not by HDS Core.
+For more comprehensive guidelines, see <https://www.nasa.gov/nasa-brand-center/brand-guidelines>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @nasa/hds-core
 
-[![Status: Pre-1.0](https://img.shields.io/badge/Status-Pre--1.0-orange.svg)](#) [![Release: v0.7.2](https://img.shields.io/badge/Release-v0.7.2-blue.svg)](https://github.com/nasa/hds-core/releases) [![USWDS: 3.13+](https://img.shields.io/badge/USWDS-3.13+-005ea2.svg)](https://github.com/uswds/uswds)
+[![Status: Pre-1.0](https://img.shields.io/badge/Status-Pre--1.0-orange.svg)](#) [![Release: v0.8.0](https://img.shields.io/badge/Release-v0.7.2-blue.svg)](https://github.com/nasa/hds-core/releases) [![USWDS: 3.13+](https://img.shields.io/badge/USWDS-3.13+-005ea2.svg)](https://github.com/uswds/uswds)
 
 > **Pre-1.0:** API and class names may change between minor versions. Not yet published to npm.
 
@@ -114,4 +114,4 @@ For architecture details and build pipeline documentation, see [ARCHITECTURE.md]
 
 ## License
 
-See [LICENSE.md](LICENSE.md) for draft. Will be finalized during NASA software release approval (in process).
+`@nasa/hds-core` is released into the public domain under [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/), except for bundled fonts (SIL OFL 1.1) and NASA trademarks/insignia. See [LICENSE.md](LICENSE.md) for full terms and attribution.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "@nasa/hds-core",
   "version": "0.8.0",
   "description": "NASA Horizon Design System (HDS) Core — design tokens, base styles, and USWDS theme configuration.",
-  "license": "SEE LICENSE.MD",
-  "private": true,
+  "license": "CC0-1.0",
   "type": "module",
   "exports": {
     "./css": "./dist/css/hds.min.css",


### PR DESCRIPTION
## What this does

Replaces the placeholder/draft license language with the final CC0 1.0 Universal Public Domain Dedication text provided by OGC, and updates all references across the repo to match.

## Changes

- **LICENSE.md**: final OGC-provided text: CC0 1.0 dedication, contribution licensing statement, bundled font exceptions (Inter, DM Mono under SIL OFL 1.1), and NASA trademark/insignia terms.
- **CONTRIBUTING.md**: new "Licensing of contributions" section stating contributions are released under CC0 1.0; intro pointer added.
- **README.md**: License section finalized (removed "draft / in process" language).
- **CREDITS.md**: updated font attribution references, added links to contributor profiles
- **package.json**: `"license": "CC0-1.0"` (SPDX identifier).

## Notes for reviewers

- LICENSE.md text is **verbatim from OGC** and should not be edited for style.
- CC0 detection: GitHub's Licensee may not auto-badge this file because it combines the CC0 dedication with attribution/trademark sections. The `CC0-1.0` SPDX field in `package.json` is the authoritative machine-readable declaration for tooling and SBOMs.
- Docs/config only: no `src/scss/**` changes, so no API snapshot update or
  changeset required.