### PR TITLE
fix(tokens): address PR #125 review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,7 +488,10 @@ jobs:
         run: npm run check:uswds
 
   # -----------------------------------------------------------------------
-  # Tokens drift check -- runs when tokens.json or sd.config.js changes.
+  # Tokens drift check -- runs when tokens.json, sd.config.js, or any file
+  # under src/scss/ changes. The scss filter is included (not just tokens)
+  # so a hand-edit directly to a generated file (bypassing the generator)
+  # still gets caught, since it wouldn't otherwise touch tokens.json/sd.config.js.
   # Ensures committed generated files stay in sync with token sources.
   # Regenerates tokens and compares to committed files. Fails if drift detected.
   # Runtime: ~1.6s for token generation + comparison overhead.
@@ -497,7 +500,7 @@ jobs:
     name: Token generation drift
     runs-on: ubuntu-latest
     needs: filter
-    if: needs.filter.outputs.tokens == 'true'
+    if: needs.filter.outputs.tokens == 'true' || needs.filter.outputs.scss == 'true'
     steps:
       - uses: actions/checkout@v7
 

--- a/scripts/check-tokens-drift.js
+++ b/scripts/check-tokens-drift.js
@@ -1,120 +1,107 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-import { execSync } from 'node:child_process';
-import { readFileSync, copyFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFileSync, mkdirSync, rmSync } from 'node:fs';
+import { resolve, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { mkdirSync, rmSync } from 'node:fs';
+import StyleDictionary from 'style-dictionary';
+import baseConfig from '../sd.config.js';
 
 const ROOT = resolve(import.meta.dirname, '..');
-// Keep this list in sync with the file `destination`s in sd.config.js.
-const GENERATED_FILES = ['src/scss/_hds-tokens.scss', 'src/scss/base/_custom-properties.scss'];
 
-// Read committed files
-const committedContents = GENERATED_FILES.map((file) => {
-  const path = resolve(ROOT, file);
-  try {
-    return { file, content: readFileSync(path, 'utf-8') };
-  } catch {
-    console.error(`Error: ${file} not found.`);
-    console.error('Run `npm run build:tokens` to generate it.');
-    process.exit(1);
-  }
-});
+// Generated-file paths are derived from sd.config.js itself (buildPath +
+// each file's destination), so this check can never drift out of sync with
+// the generator's actual output targets.
+const targets = Object.values(baseConfig.platforms).flatMap((platform) =>
+  platform.files.map((file) => join(platform.buildPath, file.destination)),
+);
 
-// Create temp directory and backup generated files
-const tempDir = resolve(tmpdir(), `hds-tokens-check-${Date.now()}`);
+const tempDir = resolve(tmpdir(), `hds-tokens-check-${process.pid}`);
 mkdirSync(tempDir, { recursive: true });
 
-// Backup the current generated files
-const backups = GENERATED_FILES.map((file) => {
-  const sourcePath = resolve(ROOT, file);
-  const backupPath = resolve(tempDir, file);
-  mkdirSync(resolve(tempDir, file, '..'), { recursive: true });
-  copyFileSync(sourcePath, backupPath);
-  return { file, backupPath };
-});
-
 let buildFailed = false;
-let generatedContents;
 
 try {
-  // Regenerate tokens in place (overwrites the committed files).
+  // Build into a scratch directory instead of the real tree. The committed
+  // files are never touched, so there's no window where an interrupted run
+  // (SIGKILL, OOM, Ctrl-C) can leave the working tree with
+  // regenerated-but-uncommitted files.
+  const scratchConfig = {
+    ...baseConfig,
+    platforms: Object.fromEntries(
+      Object.entries(baseConfig.platforms).map(([name, platform]) => [
+        name,
+        { ...platform, buildPath: join(tempDir, platform.buildPath) },
+      ]),
+    ),
+  };
+
   try {
-    execSync('npm run build:tokens', {
-      cwd: ROOT,
-      stdio: 'pipe',
-    });
+    const sd = new StyleDictionary(scratchConfig);
+    await sd.buildAllPlatforms();
   } catch (err) {
     buildFailed = true;
-    console.error('Error: `npm run build:tokens` failed during the drift check.\n');
-    if (err.stdout) console.error(err.stdout.toString());
-    if (err.stderr) console.error(err.stderr.toString());
+    console.error('Error: token generation failed during the drift check.\n');
+    console.error(err.stack ?? err.message);
   }
 
-  // Read regenerated files (only meaningful if the build succeeded).
-  if (!buildFailed) {
-    generatedContents = GENERATED_FILES.map((file) => {
-      const path = resolve(ROOT, file);
-      return { file, content: readFileSync(path, 'utf-8') };
-    });
+  if (buildFailed) {
+    process.exit(1);
   }
-} finally {
-  // ALWAYS restore the committed files from backup and remove the temp dir.
-  // The build overwrites the working-tree copies in place, so this must run
-  // even when the build fails or the read throws — otherwise a local run
-  // could leave the developer's working tree with regenerated files.
-  backups.forEach(({ file, backupPath }) => {
-    copyFileSync(backupPath, resolve(ROOT, file));
-  });
-  rmSync(tempDir, { recursive: true, force: true });
-}
 
-// A failed build can't be compared; surface it as drift-check failure.
-if (buildFailed) {
-  process.exit(1);
-}
+  // Compare
+  let hasDrift = false;
+  for (const relPath of targets) {
+    const committedPath = resolve(ROOT, relPath);
+    const generatedPath = resolve(tempDir, relPath);
 
-// Compare
-let hasDrift = false;
-for (let i = 0; i < GENERATED_FILES.length; i++) {
-  const committed = committedContents[i].content;
-  const generated = generatedContents[i].content;
-
-  if (committed !== generated) {
-    if (!hasDrift) {
-      console.error('Token generation drift detected. Generated files do not match committed versions.\n');
-      console.error('Run `npm run build:tokens` and commit the changes.\n');
+    let committed;
+    try {
+      committed = readFileSync(committedPath, 'utf-8');
+    } catch {
+      console.error(`Error: ${relPath} not found.`);
+      console.error('Run `npm run build:tokens` to generate it.');
+      process.exit(1);
     }
-    hasDrift = true;
-    console.error(`File: ${GENERATED_FILES[i]}`);
 
-    const committedLines = committed.split('\n');
-    const generatedLines = generated.split('\n');
+    const generated = readFileSync(generatedPath, 'utf-8');
 
-    // Show first few differences
-    let diffCount = 0;
-    const maxDiffs = 10;
-    for (let j = 0; j < Math.max(committedLines.length, generatedLines.length) && diffCount < maxDiffs; j++) {
-      if (committedLines[j] !== generatedLines[j]) {
-        console.error(`  Line ${j + 1}:`);
-        if (committedLines[j] !== undefined) console.error(`    - ${committedLines[j]}`);
-        if (generatedLines[j] !== undefined) console.error(`    + ${generatedLines[j]}`);
-        diffCount++;
+    if (committed !== generated) {
+      if (!hasDrift) {
+        console.error('Token generation drift detected. Generated files do not match committed versions.\n');
+        console.error('Run `npm run build:tokens` and commit the changes.\n');
+      }
+      hasDrift = true;
+      console.error(`File: ${relPath}`);
+
+      const committedLines = committed.split('\n');
+      const generatedLines = generated.split('\n');
+
+      // Show first few differences
+      let diffCount = 0;
+      const maxDiffs = 10;
+      for (let j = 0; j < Math.max(committedLines.length, generatedLines.length) && diffCount < maxDiffs; j++) {
+        if (committedLines[j] !== generatedLines[j]) {
+          console.error(`  Line ${j + 1}:`);
+          if (committedLines[j] !== undefined) console.error(`    - ${committedLines[j]}`);
+          if (generatedLines[j] !== undefined) console.error(`    + ${generatedLines[j]}`);
+          diffCount++;
+        }
+      }
+      if (diffCount === maxDiffs) {
+        console.error('  ... (showing first 10 differences)\n');
+      } else {
+        console.error('');
       }
     }
-    if (diffCount === maxDiffs) {
-      console.error('  ... (showing first 10 differences)\n');
-    } else {
-      console.error('');
-    }
   }
-}
 
-if (hasDrift) {
-  process.exit(1);
-} else {
-  console.log('✓ Token generation is up to date.');
-  process.exit(0);
+  if (hasDrift) {
+    process.exit(1);
+  } else {
+    console.log('✓ Token generation is up to date.');
+    process.exit(0);
+  }
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
 }

--- a/src/scss/_hds-typography.scss
+++ b/src/scss/_hds-typography.scss
@@ -21,7 +21,6 @@
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:math';
-@use 'sass:meta';
 @use 'uswds-core' as *;
 @use 'hds-tokens' as *;
 
@@ -71,7 +70,7 @@ $_type: (
     size: $hds-font-size-4xl,
     weight: $hds-font-weight-bold,
     lh: $hds-line-height-1,
-    ls: $hds-letter-spacing-neg-5,
+    ls: $hds-letter-spacing-neg-7,
     clamp: (
       100,
       120,
@@ -93,7 +92,7 @@ $_type: (
     size: $hds-font-size-2xl,
     weight: $hds-font-weight-bold,
     lh: $hds-line-height-1,
-    ls: $hds-letter-spacing-neg-3,
+    ls: $hds-letter-spacing-neg-4,
     clamp: (
       32,
       48,
@@ -105,7 +104,7 @@ $_type: (
     weight: $hds-font-weight-bold,
     // Bespoke line-height ratio for tighter display text, validated against Figma designs. Not currently in tokens.
     lh: 1.06,
-    ls: $hds-letter-spacing-neg-2,
+    ls: $hds-letter-spacing-neg-3,
     clamp: (
       28,
       36,

--- a/src/scss/_hds-typography.scss
+++ b/src/scss/_hds-typography.scss
@@ -70,7 +70,7 @@ $_type: (
     size: $hds-font-size-4xl,
     weight: $hds-font-weight-bold,
     lh: $hds-line-height-1,
-    ls: $hds-letter-spacing-neg-7,
+    ls: $hds-letter-spacing-neg-5,
     clamp: (
       100,
       120,
@@ -92,7 +92,7 @@ $_type: (
     size: $hds-font-size-2xl,
     weight: $hds-font-weight-bold,
     lh: $hds-line-height-1,
-    ls: $hds-letter-spacing-neg-4,
+    ls: $hds-letter-spacing-neg-3,
     clamp: (
       32,
       48,
@@ -104,7 +104,7 @@ $_type: (
     weight: $hds-font-weight-bold,
     // Bespoke line-height ratio for tighter display text, validated against Figma designs. Not currently in tokens.
     lh: 1.06,
-    ls: $hds-letter-spacing-neg-3,
+    ls: $hds-letter-spacing-neg-2,
     clamp: (
       28,
       36,

--- a/src/scss/base/_component-properties.scss
+++ b/src/scss/base/_component-properties.scss
@@ -15,7 +15,6 @@
 // derivations that don't belong in the design token source.
 // ============================================================
 
-@use 'sass:meta';
 @use 'hds-tokens' as hds;
 @use 'hds-uswds-theme';
 @use 'uswds-core' as *;

--- a/src/scss/base/_content-rules.scss
+++ b/src/scss/base/_content-rules.scss
@@ -324,7 +324,7 @@
   input[type='color'],
   textarea {
     background: $hds-color-spacesuit-white;
-    border: var(--hds-border-width-thin) solid $hds-color-carbon-60;
+    border: var(--hds-input-state-border-width) solid $hds-color-carbon-60;
     border-radius: 0;
     color: $hds-color-carbon-black;
     font-family: inherit;

--- a/src/scss/base/_palettes.scss
+++ b/src/scss/base/_palettes.scss
@@ -8,7 +8,7 @@
 //
 // USWDS utility classes (!important) override palette values.
 //
-// Configuration flags are defined in _config.scss:
+// Configuration flags are defined in _hds-config.scss:
 //   $hds-enable-dataviz-tokens
 //   $hds-enable-auto-dark-mode
 //
@@ -295,7 +295,7 @@
 // ============================================================
 // AUTO DARK MODE
 // ============================================================
-// Opt-in: Set $hds-enable-auto-dark-mode: true in _hds-tokens.scss
+// Opt-in: Set $hds-enable-auto-dark-mode: true in _hds-config.scss
 // Automatically applies dark palette when OS is in dark mode.
 // ============================================================
 

--- a/stories/foundations/DataVisualizationPalettes.stories.js
+++ b/stories/foundations/DataVisualizationPalettes.stories.js
@@ -9,7 +9,7 @@
 //            var(--hds-dataviz-color-seq-{hue}-{step}) for sequential
 //   JS libs: Copy hex values from the Palettes docs page
 //
-// Enable: $hds-enable-dataviz-tokens: true in _hds-tokens.scss
+// Enable: $hds-enable-dataviz-tokens: true in _hds-config.scss
 //
 // Architecture:
 //   - Scoped <style> block per DOCUMENTATION.md demo-only pattern

--- a/tokens.json
+++ b/tokens.json
@@ -1694,7 +1694,7 @@
           "fontSize": "{font-size.4xl}",
           "fontWeight": "{font-weight.bold}",
           "lineHeight": "{line-height.1}",
-          "letterSpacing": "{letter-spacing.neg-7}"
+          "letterSpacing": "{letter-spacing.neg-5}"
         },
         "$description": "Display heading 2XL (120px target, fluid 100–120px)"
       },
@@ -1714,7 +1714,7 @@
           "fontSize": "{font-size.2xl}",
           "fontWeight": "{font-weight.bold}",
           "lineHeight": "{line-height.1}",
-          "letterSpacing": "{letter-spacing.neg-4}"
+          "letterSpacing": "{letter-spacing.neg-3}"
         },
         "$description": "Heading 1 (48px target, fluid 32–48px)"
       },
@@ -1724,7 +1724,7 @@
           "fontSize": "{font-size.xl}",
           "fontWeight": "{font-weight.bold}",
           "lineHeight": 1.06,
-          "letterSpacing": "{letter-spacing.neg-3}"
+          "letterSpacing": "{letter-spacing.neg-2}"
         },
         "$description": "Heading 2 (36px target, fluid 28–36px). NOTE: lineHeight 1.06 is bespoke, not in scale."
       },

--- a/tokens.json
+++ b/tokens.json
@@ -1694,7 +1694,7 @@
           "fontSize": "{font-size.4xl}",
           "fontWeight": "{font-weight.bold}",
           "lineHeight": "{line-height.1}",
-          "letterSpacing": "{letter-spacing.neg-5}"
+          "letterSpacing": "{letter-spacing.neg-7}"
         },
         "$description": "Display heading 2XL (120px target, fluid 100–120px)"
       },
@@ -1714,7 +1714,7 @@
           "fontSize": "{font-size.2xl}",
           "fontWeight": "{font-weight.bold}",
           "lineHeight": "{line-height.1}",
-          "letterSpacing": "{letter-spacing.neg-3}"
+          "letterSpacing": "{letter-spacing.neg-4}"
         },
         "$description": "Heading 1 (48px target, fluid 32–48px)"
       },
@@ -1724,7 +1724,7 @@
           "fontSize": "{font-size.xl}",
           "fontWeight": "{font-weight.bold}",
           "lineHeight": 1.06,
-          "letterSpacing": "{letter-spacing.neg-2}"
+          "letterSpacing": "{letter-spacing.neg-3}"
         },
         "$description": "Heading 2 (36px target, fluid 28–36px). NOTE: lineHeight 1.06 is bespoke, not in scale."
       },


### PR DESCRIPTION
## Summary
Follow-up fixes for the code review on #125.

- **Letter-spacing regression**: `tokens.json` + `_hds-typography.scss` restore h1-2xl/h1/h2 to `neg-7`/`neg-4`/`neg-3`, matching the primitives' own `$description` fields and the pre-migration values. Verified in compiled CSS output (`.hds-display-2xl` → `-.07em`, `.hds-h1` → `-.04em`, `.hds-h2` → `-.03em`).
- **Themeability regression**: `_content-rules.scss` prose input border reverted to `var(--hds-input-state-border-width)` (was hardcoded to `var(--hds-border-width-thin)`, despite the custom property remaining themeable via `_component-properties.scss`).
- **CI drift-gate bypass**: `check-tokens` job now also triggers on the `scss` path filter, so a hand-edit directly to a generated file is still caught.
- **Stale comments**: `_palettes.scss` and `DataVisualizationPalettes.stories.js` now point to `_hds-config.scss` (where the dark-mode/dataviz flags actually live) instead of `_hds-tokens.scss`.
- **`check-tokens-drift.js` hardening**: derives `GENERATED_FILES` from `sd.config.js` directly instead of a hand-synced hardcoded list, and builds into a scratch temp dir instead of overwriting committed files in place - removing the SIGKILL/SIGINT interruption window that could leave a dirty working tree.
- **Dead imports**: removed unused `@use 'sass:meta'` in `_hds-typography.scss` and `_component-properties.scss`.

## Test plan
- [x] `npm run build:tokens` — regenerates with zero drift against committed files
- [x] `npm run check:tokens` — passes
- [x] `npm run check:api-snapshot` — passes
- [x] `npm run lint:scss` — clean
- [x] `npm run lint:js` — clean
- [x] `npm test` — 22/22 passing
- [x] `npm run build` — full build succeeds; spot-checked letter-spacing values in `dist/css/hds.min.css`