### PR TITLE
ci: auto-publish Storybook to GitHub Pages

### DIFF
--- a/.github/actions/build-storybook/action.yml
+++ b/.github/actions/build-storybook/action.yml
@@ -1,0 +1,31 @@
+# Single source of truth for the Storybook build, shared by the
+# build-storybook check in ci.yml and the deploy-storybook workflow.
+#
+# `npm run build` runs first: Storybook's staticDirs serves the compiled
+# CSS/assets from dist/ (preview-head.html links /css/*.min.css).
+#
+# Callers must check out the repo first; a local composite action isn't
+# available until then.
+
+name: 'Build Storybook'
+description: 'Install dependencies, build CSS/assets, and build the static Storybook into storybook-static/.'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-node@v7
+      with:
+        node-version: '24.15.0'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+      shell: bash
+
+    - name: Build CSS and assets
+      run: npm run build
+      shell: bash
+
+    - name: Build Storybook
+      run: npm run build-storybook
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,13 +285,13 @@ jobs:
         run: npx vitest run --project storybook --reporter=dot
 
   # -----------------------------------------------------------------------
-  # Build Storybook -- verifies the static Storybook build succeeds.
-  # Catches MDX parse errors, broken imports, and bad story configs before
-  # they reach the GitHub Pages deploy (roadmap §2).
+  # Build Storybook -- verifies the static build succeeds (catches MDX
+  # parse errors, broken imports, bad story configs) before it can reach
+  # the deploy-storybook workflow on main.
   #
-  # Does NOT use the dist artifact because it also triggers on mdx and
-  # storybook-config changes where the build job doesn't run. Always
-  # does its own full build to guarantee dist/ is available for staticDirs.
+  # Self-contained: unlike the jobs above it doesn't reuse the build
+  # artifact, since it also runs on mdx/storybook-config changes where the
+  # build job is skipped. The shared action runs the full build itself.
   # -----------------------------------------------------------------------
   build-storybook:
     name: Build / Storybook
@@ -305,19 +305,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v7
-        with:
-          node-version: '24.15.0'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build CSS and assets
-        run: npm run build
-
+      # Shared with the deploy-storybook workflow so the build sequence is
+      # defined once. See .github/actions/build-storybook.
       - name: Build Storybook
-        run: npm run build-storybook
+        uses: ./.github/actions/build-storybook
 
   # -----------------------------------------------------------------------
   # Bundle size -- downloads dist artifact, checks CSS file sizes.

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,77 @@
+# Builds the static Storybook and deploys it to GitHub Pages. Runs on
+# pushes to main that touch a build input (see paths) and on manual
+# dispatch.
+#
+# Deploys via the "GitHub Actions" Pages source using GitHub's first-party
+# Pages actions -- no gh-pages branch, no deploy token. Auth is short-lived
+# OIDC, so only the deploy job elevates to pages/id-token: write.
+#
+# Served at https://nasa.github.io/hds-core/.
+
+name: Deploy Storybook
+
+on:
+  push:
+    branches:
+      - main
+    # Allowlist: only redeploy when an input to the static build changes.
+    # Unrelated churn (root *.md, configs, other workflows) is ignored;
+    # use workflow_dispatch to force a deploy if this ever misses one.
+    paths:
+      - 'stories/**'
+      - '.storybook/**'
+      - 'src/**' # compiled into dist/, loaded by the preview
+      - 'tokens.json' # feeds generated SCSS/CSS
+      - 'sd.config.js' # token generation
+      - 'scripts/**' # docs:meta + build helpers
+      - 'svg-sprite.config.json' # sprite -> dist/ assets
+      - 'postcss.config.mjs' # affects compiled CSS
+      - '.browserslistrc' # affects autoprefixer output
+      - 'package.json' # deps / build scripts
+      - 'package-lock.json'
+      - '.github/workflows/deploy-storybook.yml'
+      - '.github/actions/build-storybook/**'
+  workflow_dispatch:
+
+# Read-only by default; the deploy job elevates to what Pages needs.
+permissions:
+  contents: read
+
+# One Pages deploy at a time, and never cancel one mid-publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Shared build; see .github/actions/build-storybook.
+      - name: Build Storybook
+        uses: ./.github/actions/build-storybook
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: storybook-static
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write # OIDC for deploy-pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What this PR does

Add a workflow that builds the static Storybook and deploys it to GitHub Pages on pushes to main (plus manual dispatch). Deploys via the "GitHub Actions" Pages source using GitHub's first-party Pages actions; auth is short-lived OIDC, so only the deploy job elevates to pages/id-token: write.

Extract the install → build CSS/assets → build Storybook sequence into a composite action (.github/actions/build-storybook) so the new deploy workflow and the existing build-storybook check in ci.yml share one build definition instead of duplicating it.

Path-filter the deploy trigger to an allowlist of files that actually feed the static build, so unrelated changes (root *.md, configs, other workflows) don't rebuild or redeploy.

Serves at https://nasa.github.io/hds-core/

## Type of change

- [ ] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API section below)
- [ ] Documentation only
- [x] Tooling or CI (no effect on published output)

## Checklist

- [x] `npm run format:fix` and `npm run lint:scss:fix` pass
- [x] `npm run lint:js` and `npm run lint:md` pass
- [x] Builds locally via:
```bash
npm ci
npm run build
npm run build-storybook
npx serve storybook-static
```

