### PR TITLE
fix: use relative asset paths in Storybook head files for Pages subpath

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -11,7 +11,7 @@
     width: 28px;
     height: 28px;
     flex-shrink: 0;
-    background: url('/src/assets/img/nasa-branding/nasa-logo.svg') center / contain no-repeat;
+    background: url('./assets/img/nasa-branding/nasa-logo.svg') center / contain no-repeat;
   }
 
   /* Temp fix for Firefox display bug; see https://github.com/storybookjs/storybook/issues/33769 */

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,8 +1,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<script src="/js/uswds-init.min.js"></script>
-<script src="/js/uswds.min.js" defer></script>
-<link rel="stylesheet" href="/css/hds.min.css" />
-<link rel="stylesheet" href="/css/hds-uswds.min.css" />
+<script src="./js/uswds-init.min.js"></script>
+<script src="./js/uswds.min.js" defer></script>
+<link rel="stylesheet" href="./css/hds.min.css" />
+<link rel="stylesheet" href="./css/hds-uswds.min.css" />
 <style>
   .hds-note__icon {
     display: inline-block;


### PR DESCRIPTION
## What this PR does

Absolute /css, /js, /src paths 404 on the /hds-core/ subpath, breaking fonts (CSS never loaded) and the sidebar NASA logo. Use relative paths instead.

## Type of change
- [ ] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API section below)
- [ ] Documentation only
- [x] Tooling or CI (no effect on published output)