### PR TITLE
fix: use relative asset paths in Storybook demos for Pages subpath

### DIFF
--- a/stories/components/IconButton.stories.js
+++ b/stories/components/IconButton.stories.js
@@ -33,7 +33,7 @@ const gridItem = (labelText, content) => `
   </div>`;
 
 const iconSvg = (name, sprite = 'hds') => {
-  const path = sprite === 'uswds' ? '/assets/img/sprite.svg' : '/assets/img/hds-sprite.svg';
+  const path = sprite === 'uswds' ? 'assets/img/sprite.svg' : 'assets/img/hds-sprite.svg';
   return `
     <svg class="hds-icon" aria-hidden="true" focusable="false">
       <use xlink:href="${path}#${name}"></use>

--- a/stories/components/Pagination.stories.js
+++ b/stories/components/Pagination.stories.js
@@ -32,12 +32,12 @@ const label = (text) => `<span class="hds-overline">${text}</span>`;
 
 const chevronLeft = `
   <svg class="hds-icon" aria-hidden="true" role="img">
-    <use href="/assets/img/hds-sprite.svg#arrow-chevron-left"></use>
+    <use href="assets/img/hds-sprite.svg#arrow-chevron-left"></use>
   </svg>`;
 
 const chevronRight = `
   <svg class="hds-icon" aria-hidden="true" role="img">
-    <use href="/assets/img/hds-sprite.svg#arrow-chevron-right"></use>
+    <use href="assets/img/hds-sprite.svg#arrow-chevron-right"></use>
   </svg>`;
 
 /**

--- a/stories/components/Table.stories.js
+++ b/stories/components/Table.stories.js
@@ -452,7 +452,7 @@ const interactiveTable = ({
         <td>
           <button class="hds-btn-icon hds-btn-icon--secondary" aria-label="Download Artemis I Press Kit" type="button">
             <svg class="hds-icon" aria-hidden="true" focusable="false">
-              <use xlink:href="/assets/img/hds-sprite.svg#download"></use>
+              <use xlink:href="assets/img/hds-sprite.svg#download"></use>
             </svg>
           </button>
         </td>
@@ -470,7 +470,7 @@ const interactiveTable = ({
         <td>
           <button class="hds-btn-icon hds-btn-icon--secondary" aria-label="Download Orion Heat Shield Analysis" type="button">
             <svg class="hds-icon" aria-hidden="true" focusable="false">
-              <use xlink:href="/assets/img/hds-sprite.svg#download"></use>
+              <use xlink:href="assets/img/hds-sprite.svg#download"></use>
             </svg>
           </button>
         </td>
@@ -488,7 +488,7 @@ const interactiveTable = ({
         <td>
           <button class="hds-btn-icon hds-btn-icon--secondary" aria-label="Download SLS Block 1 Fact Sheet" type="button">
             <svg class="hds-icon" aria-hidden="true" focusable="false">
-              <use xlink:href="/assets/img/hds-sprite.svg#download"></use>
+              <use xlink:href="assets/img/hds-sprite.svg#download"></use>
             </svg>
           </button>
         </td>
@@ -518,7 +518,7 @@ const interactiveTable = ({
         <td>
           <button class="hds-btn-icon hds-btn-icon--secondary" aria-label="Download Lunar Surface Science Plan" type="button">
             <svg class="hds-icon" aria-hidden="true" focusable="false">
-              <use xlink:href="/assets/img/hds-sprite.svg#download"></use>
+              <use xlink:href="assets/img/hds-sprite.svg#download"></use>
             </svg>
           </button>
         </td>

--- a/stories/foundations/ColorPalettes.stories.js
+++ b/stories/foundations/ColorPalettes.stories.js
@@ -7,7 +7,7 @@ export default {
 
 const icon = (name) => `
   <svg class="hds-icon" aria-hidden="true" focusable="false">
-    <use xlink:href="/assets/img/hds-sprite.svg#${name}"></use>
+    <use xlink:href="assets/img/hds-sprite.svg#${name}"></use>
   </svg>`;
 
 const paletteSample = () => `

--- a/stories/foundations/Icons.stories.js
+++ b/stories/foundations/Icons.stories.js
@@ -11,8 +11,8 @@ export default {
 // Helpers
 // ============================================================
 
-const SPRITE = '/assets/img/hds-sprite.svg';
-const USWDS_SPRITE = '/assets/img/sprite.svg';
+const SPRITE = 'assets/img/hds-sprite.svg';
+const USWDS_SPRITE = 'assets/img/sprite.svg';
 
 const icon = (name, size = '1.5rem', sprite = SPRITE) => `
   <svg class="hds-icon" aria-hidden="true" focusable="false"

--- a/stories/guides/USWDSDocumentation.stories.js
+++ b/stories/guides/USWDSDocumentation.stories.js
@@ -66,7 +66,7 @@ const page = `
             <img
               aria-hidden="true"
               class="usa-banner__header-flag"
-              src="/assets/img/us_flag_small.png"
+              src="assets/img/us_flag_small.png"
               alt=""
             />
           </div>
@@ -94,7 +94,7 @@ const page = `
           <div class="usa-banner__guidance tablet:grid-col-6">
             <img
               class="usa-banner__icon usa-media-block__img"
-              src="/assets/img/icon-dot-gov.svg"
+              src="assets/img/icon-dot-gov.svg"
               role="img"
               alt=""
               aria-hidden="true"
@@ -110,7 +110,7 @@ const page = `
           <div class="usa-banner__guidance tablet:grid-col-6">
             <img
               class="usa-banner__icon usa-media-block__img"
-              src="/assets/img/icon-https.svg"
+              src="assets/img/icon-https.svg"
               role="img"
               alt=""
               aria-hidden="true"
@@ -163,7 +163,7 @@ const page = `
       </div>
       <nav aria-label="Primary navigation," class="usa-nav">
         <button type="button" class="usa-nav__close">
-          <img src="/assets/img/usa-icons/close.svg" role="img" alt="Close" />
+          <img src="assets/img/usa-icons/close.svg" role="img" alt="Close" />
         </button>
         <ul class="usa-nav__primary usa-accordion">
           <li class="usa-nav__primary-item">
@@ -220,7 +220,7 @@ const page = `
             />
             <button class="usa-button" type="submit">
               <img
-                src="/assets/img/usa-icons-bg/search--white.svg"
+                src="assets/img/usa-icons-bg/search--white.svg"
                 class="usa-search__submit-icon"
                 alt="Search"
               />
@@ -406,7 +406,7 @@ const page = `
             <div class="mobile-lg:grid-col-auto">
               <img
                 class="usa-footer__logo-img"
-                src="/assets/img/logo-img.png"
+                src="assets/img/logo-img.png"
                 alt=""
               />
             </div>
@@ -420,7 +420,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/facebook.svg"
+                    src="assets/img/usa-icons/facebook.svg"
                     alt="Facebook"
                 /></a>
               </div>
@@ -428,7 +428,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/twitter.svg"
+                    src="assets/img/usa-icons/twitter.svg"
                     alt="Twitter"
                 /></a>
               </div>
@@ -436,7 +436,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/youtube.svg"
+                    src="assets/img/usa-icons/youtube.svg"
                     alt="YouTube"
                 /></a>
               </div>
@@ -444,7 +444,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/instagram.svg"
+                    src="assets/img/usa-icons/instagram.svg"
                     alt="Instagram"
                 /></a>
               </div>
@@ -452,7 +452,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/rss_feed.svg"
+                    src="assets/img/usa-icons/rss_feed.svg"
                     alt="RSS"
                 /></a>
               </div>
@@ -485,7 +485,7 @@ const page = `
           <a href="javascript:void(0)" class="usa-identifier__logo"
             ><img
               class="usa-identifier__logo-img"
-              src="/assets/img/circle-gray-20.svg"
+              src="assets/img/circle-gray-20.svg"
               alt="&lt;Parent agency&gt; logo"
               role="img"
           /></a>

--- a/stories/guides/USWDSForm.stories.js
+++ b/stories/guides/USWDSForm.stories.js
@@ -133,7 +133,7 @@ const beforeYouStart = `
             <li class="usa-icon-list__item">
               <div class="usa-icon-list__icon text-green">
                 <svg class="usa-icon" aria-hidden="true" role="img">
-                  <use href="/assets/img/sprite.svg#check_circle"></use>
+                  <use href="assets/img/sprite.svg#check_circle"></use>
                 </svg>
               </div>
               <div class="usa-icon-list__content">
@@ -143,7 +143,7 @@ const beforeYouStart = `
             <li class="usa-icon-list__item">
               <div class="usa-icon-list__icon text-green">
                 <svg class="usa-icon" aria-hidden="true" role="img">
-                  <use href="/assets/img/sprite.svg#check_circle"></use>
+                  <use href="assets/img/sprite.svg#check_circle"></use>
                 </svg>
               </div>
               <div class="usa-icon-list__content">
@@ -154,7 +154,7 @@ const beforeYouStart = `
             <li class="usa-icon-list__item">
               <div class="usa-icon-list__icon text-green">
                 <svg class="usa-icon" aria-hidden="true" role="img">
-                  <use href="/assets/img/sprite.svg#check_circle"></use>
+                  <use href="assets/img/sprite.svg#check_circle"></use>
                 </svg>
               </div>
               <div class="usa-icon-list__content">
@@ -165,7 +165,7 @@ const beforeYouStart = `
             <li class="usa-icon-list__item">
               <div class="usa-icon-list__icon text-green">
                 <svg class="usa-icon" aria-hidden="true" role="img">
-                  <use href="/assets/img/sprite.svg#check_circle"></use>
+                  <use href="assets/img/sprite.svg#check_circle"></use>
                 </svg>
               </div>
               <div class="usa-icon-list__content">
@@ -374,7 +374,7 @@ const sexModal = `
         data-close-modal
       >
         <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-          <use href="/assets/img/sprite.svg#close"></use>
+          <use href="assets/img/sprite.svg#close"></use>
         </svg>
       </button>
     </div>
@@ -616,7 +616,7 @@ const step3 = `
         <div class="usa-input-group">
           <div class="usa-input-prefix" aria-hidden="true">
             <svg aria-hidden="true" role="img" focusable="false" class="usa-icon">
-              <use href="/assets/img/sprite.svg#attach_money"></use>
+              <use href="assets/img/sprite.svg#attach_money"></use>
             </svg>
           </div>
           <input

--- a/stories/guides/USWDSLandingPage.stories.js
+++ b/stories/guides/USWDSLandingPage.stories.js
@@ -67,7 +67,7 @@ const page = `
             <img
               aria-hidden="true"
               class="usa-banner__header-flag"
-              src="/assets/img/us_flag_small.png"
+              src="assets/img/us_flag_small.png"
               alt=""
             />
           </div>
@@ -95,7 +95,7 @@ const page = `
           <div class="usa-banner__guidance tablet:grid-col-6">
             <img
               class="usa-banner__icon usa-media-block__img"
-              src="/assets/img/icon-dot-gov.svg"
+              src="assets/img/icon-dot-gov.svg"
               role="img"
               alt=""
               aria-hidden="true"
@@ -111,7 +111,7 @@ const page = `
           <div class="usa-banner__guidance tablet:grid-col-6">
             <img
               class="usa-banner__icon usa-media-block__img"
-              src="/assets/img/icon-https.svg"
+              src="assets/img/icon-https.svg"
               role="img"
               alt=""
               aria-hidden="true"
@@ -208,7 +208,7 @@ const page = `
           <div class="usa-media-block tablet:grid-col">
             <img
               class="usa-media-block__img"
-              src="/assets/img/circle-124.png"
+              src="assets/img/circle-124.png"
               alt="Alt text"
             />
             <div class="usa-media-block__body">
@@ -225,7 +225,7 @@ const page = `
           <div class="usa-media-block tablet:grid-col">
             <img
               class="usa-media-block__img"
-              src="/assets/img/circle-124.png"
+              src="assets/img/circle-124.png"
               alt="Alt text"
             />
             <div class="usa-media-block__body">
@@ -244,7 +244,7 @@ const page = `
           <div class="usa-media-block tablet:grid-col">
             <img
               class="usa-media-block__img"
-              src="/assets/img/circle-124.png"
+              src="assets/img/circle-124.png"
               alt="Alt text"
             />
             <div class="usa-media-block__body">
@@ -261,7 +261,7 @@ const page = `
           <div class="usa-media-block tablet:grid-col">
             <img
               class="usa-media-block__img"
-              src="/assets/img/circle-124.png"
+              src="assets/img/circle-124.png"
               alt="Alt text"
             />
             <div class="usa-media-block__body">
@@ -337,7 +337,7 @@ const page = `
             <div class="mobile-lg:grid-col-auto">
               <img
                 class="usa-footer__logo-img"
-                src="/assets/img/logo-img.png"
+                src="assets/img/logo-img.png"
                 alt=""
               />
             </div>
@@ -351,7 +351,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/facebook.svg"
+                    src="assets/img/usa-icons/facebook.svg"
                     alt="Facebook"
                 /></a>
               </div>
@@ -359,7 +359,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/twitter.svg"
+                    src="assets/img/usa-icons/twitter.svg"
                     alt="Twitter"
                 /></a>
               </div>
@@ -367,7 +367,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/youtube.svg"
+                    src="assets/img/usa-icons/youtube.svg"
                     alt="YouTube"
                 /></a>
               </div>
@@ -375,7 +375,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/instagram.svg"
+                    src="assets/img/usa-icons/instagram.svg"
                     alt="Instagram"
                 /></a>
               </div>
@@ -383,7 +383,7 @@ const page = `
                 <a class="usa-social-link" href="javascript:void(0);"
                   ><img
                     class="usa-social-link__icon"
-                    src="/assets/img/usa-icons/rss_feed.svg"
+                    src="assets/img/usa-icons/rss_feed.svg"
                     alt="RSS"
                 /></a>
               </div>
@@ -416,7 +416,7 @@ const page = `
           <a href="javascript:void(0)" class="usa-identifier__logo"
             ><img
               class="usa-identifier__logo-img"
-              src="/assets/img/circle-gray-20.svg"
+              src="assets/img/circle-gray-20.svg"
               alt="&lt;Parent agency&gt; logo"
               role="img"
           /></a>

--- a/stories/helpers/Note.jsx
+++ b/stories/helpers/Note.jsx
@@ -20,7 +20,7 @@ export function Note({ type, children }) {
       <div className="usa-alert__body">
         <div className="usa-alert__text">
           <svg className="hds-icon hds-note__icon" aria-hidden="true" focusable="false">
-            <use xlinkHref={`/assets/img/${icon.sprite}.svg#${icon.id}`} />
+            <use xlinkHref={`assets/img/${icon.sprite}.svg#${icon.id}`} />
           </svg>
           <strong>{labels[resolvedType]}:</strong>
           <p>{children}</p>


### PR DESCRIPTION
## What this PR does

Rendered story demos referenced sprites and images with absolute paths (/assets/...), which 404 on the GitHub Pages subpath deploy because they resolve against the domain root. Icons rendered blank and USWDS demo images were missing.

Switch the nine rendered-demo files to relative paths (assets/...) so they resolve correctly at both localhost and the Pages subpath.

## Type of change
- [ ] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API section below)
- [ ] Documentation only
- [x] Tooling or CI (no effect on published output)

## Checklist
- [x] `npm run format:fix` and `npm run lint:scss:fix` pass
- [x] `npm run lint:js` and `npm run lint:md` pass
- [ ] Tested across all 6 palettes in Storybook
- [ ] Tested across mobile, tablet, and desktop viewports
- [x] Automated a11y checks pass (`npm test`)
- [ ] Storybook documentation updated (if component changed)

## Notes for reviewers
Tested locally in both live and static Storybook builds.

