### PR TITLE
Fix error input hover border

### DIFF
--- a/.changeset/calm-inputs-hover.md
+++ b/.changeset/calm-inputs-hover.md
@@ -1,0 +1,5 @@
+---
+'@nasa/hds-core': patch
+---
+
+Preserve the error indicator border when hovering text inputs, textareas, and selects.

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -154,9 +154,9 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
 // Light: C20 → C40 (= --hds-palette-control-border).
 // Dark: C80 → inferred C60 (= --hds-palette-border on dark).
 
-.usa-input:hover:not(:disabled, :focus-visible),
-.usa-textarea:hover:not(:disabled, :focus-visible),
-.usa-select:hover:not(:disabled, :focus-visible) {
+.usa-input:hover:not(:disabled, :focus-visible, .usa-input--error),
+.usa-textarea:hover:not(:disabled, :focus-visible, .usa-input--error),
+.usa-select:hover:not(:disabled, :focus-visible, .usa-input--error) {
   border-color: var(--hds-palette-control-border);
 }
 

--- a/stories/components/TextInput.stories.js
+++ b/stories/components/TextInput.stories.js
@@ -341,6 +341,14 @@ export const ErrorModern = {
       hint: 'e.g., mission-lead@nasa.gov',
       error: 'Incorrect email address format',
     }),
+  play: async ({ canvas, userEvent }) => {
+    const input = canvas.getByRole('textbox', { name: 'Email address' });
+    const errorBorderColor = getComputedStyle(input).borderTopColor;
+
+    await userEvent.hover(input);
+
+    await expect(getComputedStyle(input).borderTopColor).toBe(errorBorderColor);
+  },
 };
 
 // Error with multiline message — confirms icon stays top-aligned


### PR DESCRIPTION
## What this PR does

Prevents the neutral input hover rule from overriding the error-state border on text inputs, textareas, and selects. Adds a Storybook interaction regression check that verifies an error input keeps the same border color while hovered.

The root cause was the hover selector's higher specificity: it excluded disabled and focused controls, but not `.usa-input--error`, so its neutral border color won over the error rule.

Closes #147

## Type of change

- [x] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API section below)
- [ ] Documentation only
- [ ] Tooling or CI (no effect on published output)

## Checklist

- [x] `npm run format:fix` and `npm run lint:scss:fix` pass
- [x] `npm run lint:js` and `npm run lint:md` pass
- [ ] Tested across all 6 palettes in Storybook
- [ ] Tested across mobile, tablet, and desktop viewports
- [x] Automated a11y checks pass (`npm test`)
- [ ] Storybook documentation updated (if component changed)

## Public API and changesets

- [x] Ran `npm run check:api-snapshot` and reviewed the result
- [x] Changeset added with a patch bump
- [x] Bump level matches the semver rubric

## Visual review

The `Components/Text Input` error story now includes an automated hover-state assertion. No viewport-dependent layout is changed.

## Notes for reviewers

Validation completed locally:

- `npm run build`
- `npm test` (240 tests)
- `npm run lint`
- `npm run format`
- `npm run check:api-snapshot`
- `npm run check:tokens`
