### PR TITLE
fix: consolidate published package contents

### DIFF
--- a/.changeset/lucky-assets-consolidate.md
+++ b/.changeset/lucky-assets-consolidate.md
@@ -1,0 +1,36 @@
+---
+'@nasa-hds/core': minor
+---
+
+Consolidate published package contents onto a single asset tree, and make asset paths configurable from Sass
+
+**BREAKING CHANGE — `src/assets/` is no longer published.** The tarball shipped HDS's fonts and icons twice: `src/assets/` (120 files) was a strict subset of `dist/assets/`. Only `dist/assets/` ships now.
+
+If you copy assets out of the package, copy from `dist/assets/` instead of `src/assets/`. It is one complete tree and needs only a single copy target — it contains everything `src/assets/` had, plus Public Sans, the full USWDS image tree, and the generated sprite at `img/hds-sprite.svg`. Multi-target copy configs (HDS fonts + HDS img + Public Sans from `@uswds/uswds` + USWDS img) collapse to one:
+
+```js
+// vite-plugin-static-copy
+{ src: 'node_modules/@nasa-hds/core/dist/assets', dest: '', rename: 'assets' }
+```
+
+Note that the sprite now arrives at `assets/img/hds-sprite.svg`, not `assets/hds-sprite.svg` — update any `<use href>` accordingly.
+
+**BREAKING CHANGE — the `./assets` export is now `./assets/*`.** The deprecated trailing-slash form `"./assets": "./dist/assets/"` has been replaced with the subpath-pattern form. Import individual files: `@nasa-hds/core/assets/img/hds-sprite.svg`, `@nasa-hds/core/assets/fonts/inter/Inter-Regular.woff2`.
+
+**New: configurable asset paths.** Three variables are added to the public Sass surface in `_hds-config.scss`, so you no longer have to copy assets next to your compiled CSS:
+
+```scss
+@use '@nasa-hds/core/scss' with (
+  $hds-asset-path: '/static/hds-assets'
+);
+```
+
+| Variable          | Default                      |
+| ----------------- | ---------------------------- |
+| `$hds-asset-path` | `'../assets'`                |
+| `$hds-image-path` | `'#{$hds-asset-path}/img'`   |
+| `$hds-font-path`  | `'#{$hds-asset-path}/fonts'` |
+
+Setting `$hds-asset-path` retargets every `url()` HDS emits — webfonts, USWDS imagery, and HDS icons alike. Compiled CSS output is unchanged at the default value.
+
+**New: `./js/uswds` export** for the USWDS JavaScript pass-through: `import '@nasa-hds/core/js/uswds'`. This was already shipping in `dist/js/`, just not addressable through the `exports` map.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ dist/
     hds-uswds.min.css.map
     hds-dataviz.min.css # Optional: data visualization color palettes
     hds-dataviz.min.css.map
-  assets/
+  assets/               # The complete HDS asset tree — copy this one directory
     fonts/              # Inter, DM Mono, Public Sans (woff2)
-    img/                # USWDS images and HDS icons
+    img/                # USWDS images, HDS icons, NASA branding, hds-sprite.svg
   js/
-    uswds.js            # USWDS JavaScript (unmodified)
+    uswds.min.js        # USWDS JavaScript (unmodified)
+    uswds-init.min.js
 src/
   scss/                 # Public Sass API: tokens, mixins, theme config
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,7 +213,11 @@ Always set **both** `color` and `fill` on icon containers. `<path fill="currentC
 
 ### Asset paths
 
-Always use `../assets/img/` in component styles. Configured in `_hds-uswds-theme.scss` via `$theme-image-path` and `$theme-font-path`.
+Never hardcode `../assets/...` in component styles — always interpolate the public config variable: `url('#{$hds-image-path}/hds-icons/name.svg')`, with `@use 'hds-config' as *;` in the file header.
+
+`$hds-asset-path`, `$hds-image-path`, and `$hds-font-path` are declared in `_hds-config.scss` (public Sass surface, adopter-configurable via `@use ... with (...)`). Both `_hds-uswds-theme.scss` and `_hds-uswds-theme-utils.scss` feed them into USWDS's `$theme-image-path` / `$theme-font-path`, which is what emits the `@font-face` and USWDS image `url()`s. `hds.scss` and `hds-uswds.scss` `@forward 'hds-config'` before the theme so adopter configuration reaches it.
+
+Sass does not rewrite `url()`. These strings are emitted verbatim into compiled CSS, so the default `'../assets'` is what makes `dist/css/*.min.css` resolve against its sibling `dist/assets/`.
 
 ## Focus Ring Architecture
 

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "./scss": "./src/scss/hds.scss",
     "./scss/uswds": "./src/scss/hds-uswds.scss",
     "./scss/dataviz": "./src/scss/hds-dataviz.scss",
-    "./assets": "./dist/assets/"
+    "./js/uswds": "./dist/js/uswds.min.js",
+    "./assets/*": "./dist/assets/*"
   },
   "files": [
     "dist/",
-    "src/scss/",
-    "src/assets/"
+    "src/scss/"
   ],
   "scripts": {
     "sass:hds": "sass src/scss/hds.scss dist/css/hds.css --load-path=node_modules/@uswds/uswds/packages --load-path=src/scss --source-map --style=expanded --quiet-deps",

--- a/public-api.snapshot.txt
+++ b/public-api.snapshot.txt
@@ -275,8 +275,11 @@ src/scss/hds-uswds.scss
 --hds-dataviz-color-seq-yellow-90
 
 ## Sass Variables (_hds-config.scss)
+$hds-asset-path
 $hds-enable-auto-dark-mode
 $hds-enable-dataviz-tokens
+$hds-font-path
+$hds-image-path
 
 ## Sass Variables (_hds-tokens.scss)
 $hds-border-radius

--- a/src/scss/_hds-config.scss
+++ b/src/scss/_hds-config.scss
@@ -16,3 +16,26 @@ $hds-enable-dataviz-tokens: false !default;
 /// Enable automatic dark mode detection via prefers-color-scheme
 /// @type Boolean
 $hds-enable-auto-dark-mode: false !default;
+
+/// Base path to the HDS asset tree, as emitted into compiled CSS url()
+/// strings. Sass does NOT rewrite url() — this value is written verbatim
+/// into the output, so it must resolve relative to the final CSS file (or
+/// be root-relative / absolute).
+///
+/// The default assumes the published layout, where the stylesheet sits in
+/// `dist/css/` alongside `dist/assets/`. Override it when assets are
+/// served from a fixed location instead of copied next to the CSS.
+/// @type String
+/// @example scss
+///   @use '@nasa-hds/core/scss' with ($hds-asset-path: '/static/hds-assets');
+$hds-asset-path: '../assets' !default;
+
+/// Path to the image tree (USWDS imagery, HDS icons, NASA branding, and
+/// the generated `hds-sprite.svg`). Derived from $hds-asset-path.
+/// @type String
+$hds-image-path: '#{$hds-asset-path}/img' !default;
+
+/// Path to the webfont tree (Inter, DM Mono, Public Sans). Derived from
+/// $hds-asset-path. USWDS emits its @font-face url()s from this value.
+/// @type String
+$hds-font-path: '#{$hds-asset-path}/fonts' !default;

--- a/src/scss/_hds-uswds-theme-utils.scss
+++ b/src/scss/_hds-uswds-theme-utils.scss
@@ -7,6 +7,7 @@
 // ============================================================
 
 @use 'hds-tokens' as hds;
+@use 'hds-config' as *;
 @use 'sass:map';
 @use 'uswds-core' with (
   // ----------------------------------------------------------
@@ -19,8 +20,8 @@
   // ----------------------------------------------------------
   // Asset Paths
   // ----------------------------------------------------------
-  $theme-image-path: '../assets/img',
-  $theme-font-path: '../assets/fonts',
+  $theme-image-path: $hds-image-path,
+  $theme-font-path: $hds-font-path,
 
   // ----------------------------------------------------------
   // Base Color Family — Carbon Scale

--- a/src/scss/_hds-uswds-theme.scss
+++ b/src/scss/_hds-uswds-theme.scss
@@ -47,6 +47,7 @@
 // ============================================================
 
 @use 'hds-tokens' as hds;
+@use 'hds-config' as *;
 @use 'sass:map';
 @use 'uswds-core' with (
   // ----------------------------------------------------------
@@ -60,8 +61,8 @@
   // ----------------------------------------------------------
   // Asset Paths
   // ----------------------------------------------------------
-  $theme-image-path: '../assets/img',
-  $theme-font-path: '../assets/fonts',
+  $theme-image-path: $hds-image-path,
+  $theme-font-path: $hds-font-path,
 
   // ----------------------------------------------------------
   // Base Color Family — Carbon Scale

--- a/src/scss/base/_content-rules.scss
+++ b/src/scss/base/_content-rules.scss
@@ -28,6 +28,7 @@
 
 @use 'sass:map';
 @use 'uswds-core' as *;
+@use 'hds-config' as *;
 @use 'hds-tokens' as *;
 @use 'hds-mixins' as *;
 @use 'hds-typography' as *;
@@ -120,7 +121,7 @@
       display: block;
       height: 24px;
       width: 24px;
-      mask-image: url('../assets/img/hds-icons/quote.svg');
+      mask-image: url('#{$hds-image-path}/hds-icons/quote.svg');
       mask-position: center;
       mask-repeat: no-repeat;
       mask-size: 100%;

--- a/src/scss/components/_accordion.scss
+++ b/src/scss/components/_accordion.scss
@@ -26,6 +26,7 @@
 // ============================================================
 
 @use 'uswds-core' as *;
+@use 'hds-config' as *;
 @use 'hds-tokens' as *;
 @use 'hds-mixins' as *;
 
@@ -119,7 +120,7 @@
 
     // Chevron icon via mask
     background-color: var(--hds-palette-utility-icon, #{$hds-color-carbon-black});
-    mask-image: url('../assets/img/hds-icons/arrow-chevron-down.svg');
+    mask-image: url('#{$hds-image-path}/hds-icons/arrow-chevron-down.svg');
     mask-repeat: no-repeat;
     mask-position: center;
     mask-size: 0.75em;

--- a/src/scss/components/_blockquote.scss
+++ b/src/scss/components/_blockquote.scss
@@ -45,6 +45,7 @@
 
 @use 'sass:map';
 @use 'uswds-core' as *;
+@use 'hds-config' as *;
 @use 'hds-tokens' as *;
 @use 'hds-mixins' as *;
 @use 'hds-typography' as *;
@@ -79,7 +80,7 @@
     display: block;
     height: 24px;
     width: 24px;
-    mask-image: url('../assets/img/hds-icons/quote.svg');
+    mask-image: url('#{$hds-image-path}/hds-icons/quote.svg');
     mask-position: center;
     mask-repeat: no-repeat;
     mask-size: 100%;

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -48,6 +48,7 @@
 
 @use 'sass:map';
 @use 'uswds-core' as *;
+@use 'hds-config' as *;
 @use 'hds-tokens' as *;
 @use 'hds-mixins' as *;
 @use 'hds-typography' as *;
@@ -465,7 +466,7 @@ $hds-checkbox-icon: url("data:image/svg+xml,%3Csvg viewBox='-2 -2 24 24' xmlns='
     display: block;
     flex-shrink: 0;
     height: 18px;
-    mask-image: url('../assets/img/hds-icons/error.svg');
+    mask-image: url('#{$hds-image-path}/hds-icons/error.svg');
     mask-position: center;
     mask-repeat: no-repeat;
     mask-size: 21.6px 21.6px;

--- a/src/scss/components/_link.scss
+++ b/src/scss/components/_link.scss
@@ -17,6 +17,7 @@
 // ============================================================
 
 @use 'uswds-core' as *;
+@use 'hds-config' as *;
 @use 'hds-tokens' as *;
 @use 'hds-mixins' as *;
 
@@ -69,7 +70,7 @@
   // icon to render. Composing components that don't want the
   // padding-left (e.g. primary arrow button) defend locally.
   margin: 0;
-  mask-image: url('../assets/img/hds-icons/arrow-line-diagonal.svg'), linear-gradient(transparent, transparent);
+  mask-image: url('#{$hds-image-path}/hds-icons/arrow-line-diagonal.svg'), linear-gradient(transparent, transparent);
   mask-size: 0.75em;
   mask-position: center;
   mask-repeat: no-repeat;

--- a/src/scss/components/_navigation.scss
+++ b/src/scss/components/_navigation.scss
@@ -12,6 +12,7 @@
 // ============================================================
 
 @use 'uswds-core' as *;
+@use 'hds-config' as *;
 @use 'hds-tokens' as *;
 @use 'hds-mixins' as *;
 
@@ -89,12 +90,12 @@
 
   &[aria-expanded='true'] span::after {
     mask-image:
-      url('../assets/img/hds-icons/arrow-chevron-up.svg'), linear-gradient(transparent, transparent) !important;
+      url('#{$hds-image-path}/hds-icons/arrow-chevron-up.svg'), linear-gradient(transparent, transparent) !important;
   }
 
   &[aria-expanded='false'] span::after {
     mask-image:
-      url('../assets/img/hds-icons/arrow-chevron-down.svg'), linear-gradient(transparent, transparent) !important;
+      url('#{$hds-image-path}/hds-icons/arrow-chevron-down.svg'), linear-gradient(transparent, transparent) !important;
   }
 }
 
@@ -105,7 +106,7 @@
   &[aria-expanded='false'] {
     background-color: currentcolor;
     background-image: none;
-    mask-image: url('../assets/img/hds-icons/arrow-chevron-down.svg');
+    mask-image: url('#{$hds-image-path}/hds-icons/arrow-chevron-down.svg');
     mask-position: right center;
     mask-repeat: no-repeat;
     mask-size: 1.2rem;
@@ -114,7 +115,7 @@
   &[aria-expanded='true'] {
     background-color: currentcolor;
     background-image: none;
-    mask-image: url('../assets/img/hds-icons/arrow-chevron-up.svg');
+    mask-image: url('#{$hds-image-path}/hds-icons/arrow-chevron-up.svg');
     mask-position: right center;
     mask-repeat: no-repeat;
     mask-size: 1.2rem;

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -52,6 +52,7 @@
 
 @use 'sass:map';
 @use 'uswds-core' as *;
+@use 'hds-config' as *;
 @use 'hds-tokens' as *;
 
 // ── Internal table color tokens ───────────────────────────────
@@ -273,7 +274,7 @@ $table-border-dark: #2e2e31; // rgba(255,255,255,0.1) over Carbon 90
 
   // --- Base sort button as icon container ---
   th[data-sortable] .usa-table__header__button {
-    mask-image: url('../assets/img/hds-icons/arrow-filled-down.svg');
+    mask-image: url('#{$hds-image-path}/hds-icons/arrow-filled-down.svg');
     mask-repeat: no-repeat;
     mask-position: center;
     mask-size: 1.25rem;
@@ -301,7 +302,7 @@ $table-border-dark: #2e2e31; // rgba(255,255,255,0.1) over Carbon 90
   // --- Sorted ascending: filled arrow up, NASA Blue ---
   th[data-sortable][aria-sort='ascending'] .usa-table__header__button {
     background-color: $hds-color-nasa-blue;
-    mask-image: url('../assets/img/hds-icons/arrow-filled-up.svg');
+    mask-image: url('#{$hds-image-path}/hds-icons/arrow-filled-up.svg');
   }
 
   // --- Sorted icon persists on hover ---

--- a/src/scss/hds-uswds.scss
+++ b/src/scss/hds-uswds.scss
@@ -19,6 +19,11 @@
 // moves from this file's layer block into hds.scss.
 // ============================================================
 
+// Expose HDS configuration flags (asset paths, feature flags) so adopters
+// can set them via `@use '@nasa-hds/core/scss/uswds' with (...)`. Must be
+// forwarded before the theme, which reads $hds-image-path / $hds-font-path.
+@forward 'hds-config';
+
 // Configure USWDS with the tweaked HDS theme settings that include USWDS utilities (must be first USWDS load)
 @forward 'hds-uswds-theme-utils';
 @use 'sass:meta';

--- a/src/scss/hds.scss
+++ b/src/scss/hds.scss
@@ -24,6 +24,11 @@
 //   - CSS @layer blocks       — Base, Components, USWDS
 // ============================================================
 
+// Expose HDS configuration flags (asset paths, feature flags) so adopters
+// can set them via `@use '@nasa-hds/core/scss' with (...)`. Must be forwarded
+// before the theme, which reads $hds-image-path / $hds-font-path.
+@forward 'hds-config';
+
 // Configure USWDS with HDS values (must be first USWDS load)
 @forward 'hds-uswds-theme';
 @use 'sass:meta';

--- a/stories/guides/ReactSetup.mdx
+++ b/stories/guides/ReactSetup.mdx
@@ -27,7 +27,7 @@ Use a single compiled stylesheet that includes USWDS base styles, HDS overrides,
 npm install -D vite-plugin-static-copy
 ```
 
-HDS Core's Sass source references fonts and icons using relative paths (e.g. `url('../assets/fonts/...')`). The pre-compiled CSS path resolves these automatically, but Sass-from-source requires you to copy the assets to the expected location in your build output.
+HDS Core's Sass source references fonts and icons using relative paths (e.g. `url('../assets/fonts/...')`). Sass never rewrites `url()`, so these strings are emitted verbatim into your compiled CSS. The pre-compiled CSS path resolves them automatically, but Sass-from-source requires you to copy the published asset tree to the location your compiled CSS expects — or to point HDS at wherever you already serve assets from with `$hds-asset-path` (see step 5).
 
 **2. Your Sass entry point:**
 
@@ -64,14 +64,10 @@ export default defineConfig({
     react(),
     viteStaticCopy({
       targets: [
-        // HDS fonts (DM Mono, Inter) — lands at dist/assets/fonts/
-        { src: 'node_modules/@nasa-hds/core/src/assets/fonts', dest: 'assets', rename: { stripBase: 5 } },
-        // HDS icon SVGs (accordion, table sort, external link, form error)
-        { src: 'node_modules/@nasa-hds/core/src/assets/img', dest: 'assets', rename: { stripBase: 5 } },
-        // Public Sans — from USWDS — lands at dist/assets/fonts/public-sans/
-        { src: 'node_modules/@uswds/uswds/dist/fonts/public-sans', dest: 'assets/fonts', rename: { stripBase: 5 } },
-        // USWDS images (checkboxes, radio indicators, etc.)
-        { src: 'node_modules/@uswds/uswds/dist/img', dest: 'assets', rename: { stripBase: 4 } },
+        // The whole published HDS asset tree — fonts (DM Mono, Inter,
+        // Public Sans), USWDS images, HDS icon SVGs, and hds-sprite.svg.
+        // Lands at dist/assets/{fonts,img}/.
+        { src: 'node_modules/@nasa-hds/core/dist/assets', dest: '', rename: 'assets' },
       ],
     }),
   ],
@@ -79,14 +75,27 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         loadPaths: ['node_modules/@uswds/uswds/packages', 'node_modules/@nasa-hds/core/src/scss'],
-        loadPaths: ['node_modules/@uswds/uswds/packages', 'node_modules/@nasa-hds/core/src/scss'],
       },
     },
   },
 });
 ```
 
-The `stripBase` number strips leading path segments from each copied file so it lands at the path the compiled CSS expects. During the build you will see "didn't resolve at build time" warnings for font and image URLs; these are expected and safe. The files are placed by `viteStaticCopy` after Vite's CSS transform phase and will be served correctly at runtime.
+`dist/assets/` in the published package is one complete tree — you no longer need separate targets for HDS fonts, HDS icons, Public Sans, and the USWDS image tree. During the build you will see "didn't resolve at build time" warnings for font and image URLs; these are expected and safe. The files are placed by `viteStaticCopy` after Vite's CSS transform phase and will be served correctly at runtime.
+
+**5. Alternative: point HDS at your existing asset location.**
+
+If you already serve static assets from a fixed URL and would rather not copy the tree next to your CSS, skip `vite-plugin-static-copy` and configure the asset path instead:
+
+```scss
+// src/styles/index.scss
+@use '@nasa-hds/core/scss' with (
+  $hds-asset-path: '/static/hds-assets'
+);
+@forward './my-project-styles';
+```
+
+Every emitted `url()` — webfonts, USWDS imagery, and HDS icons alike — is then written relative to that base. Copy `node_modules/@nasa-hds/core/dist/assets` to whatever location you chose. `$hds-image-path` and `$hds-font-path` are also configurable individually if the two trees live apart.
 
 ### Pre-compiled CSS setup
 
@@ -173,7 +182,7 @@ Some HDS components have no USWDS equivalent and no react-uswds wrapper. They ar
 }
 <button type="button" className="hds-btn-icon hds-btn-icon--utility">
   <svg className="hds-glyph" role="img" aria-hidden="true">
-    <use href="/assets/hds-sprite.svg#close" />
+    <use href="/assets/img/hds-sprite.svg#close" />
   </svg>
   <span className="usa-sr-only">Close</span>
 </button>;
@@ -184,7 +193,7 @@ Some HDS components have no USWDS equivalent and no react-uswds wrapper. They ar
 <p className="hds-overline">Mission Status</p>;
 ```
 
-<Note>**Icon sprite:** HDS icon buttons reference an SVG sprite (`hds-sprite.svg#id`). Copy the sprite from `@nasa-hds/core` into your app's static/public directory (or import it as a URL through your bundler) and point the `<use href>` at that path. The `/assets/...` path above is illustrative.</Note>
+<Note>**Icon sprite:** HDS icon buttons reference an SVG sprite (`hds-sprite.svg#id`). The sprite ships at `dist/assets/img/hds-sprite.svg`, so the asset copy in step 4 already places it at `/assets/img/hds-sprite.svg` — no separate target needed. Point the `<use href>` at wherever the tree lands in your build (or import the sprite as a URL through your bundler). The `/assets/...` path above is illustrative.</Note>
 
 Check each component's Guidance page in Storybook for the correct markup.
 

--- a/stories/guides/SassConfiguration.mdx
+++ b/stories/guides/SassConfiguration.mdx
@@ -31,12 +31,23 @@ Most projects won't need to change anything — HDS Core configures USWDS with t
 
 ### Asset paths
 
-Adjust these if your build pipeline outputs assets to a different location than the HDS Core default.
+Adjust these if your build pipeline serves assets from a different location than the HDS Core default. Unlike the `$theme-*` settings above, these are HDS variables and **are** configurable from your own stylesheet:
 
-| Setting             | HDS Default         | When to change                                                           |
-| ------------------- | ------------------- | ------------------------------------------------------------------------ |
-| `$theme-image-path` | `'../assets/img'`   | Your compiled CSS is not one directory above your `assets/img/` folder   |
-| `$theme-font-path`  | `'../assets/fonts'` | Your compiled CSS is not one directory above your `assets/fonts/` folder |
+```scss
+@use '@nasa-hds/core/scss' with (
+  $hds-asset-path: '/static/hds-assets'
+);
+```
+
+| Setting           | HDS Default                  | When to change                                                         |
+| ----------------- | ---------------------------- | ---------------------------------------------------------------------- |
+| `$hds-asset-path` | `'../assets'`                | Your compiled CSS is not one directory above the copied `assets/` tree |
+| `$hds-image-path` | `'#{$hds-asset-path}/img'`   | Images are served from somewhere other than `<asset path>/img`         |
+| `$hds-font-path`  | `'#{$hds-asset-path}/fonts'` | Webfonts are served from somewhere other than `<asset path>/fonts`     |
+
+Setting `$hds-asset-path` retargets every `url()` HDS emits — webfonts, USWDS imagery, and HDS icons — because HDS feeds these values into USWDS's `$theme-image-path` and `$theme-font-path` for you. Sass does not rewrite `url()`, so the value is written verbatim into your compiled CSS: it must resolve relative to the final stylesheet, or be root-relative or absolute.
+
+Do not set USWDS's `$theme-image-path` / `$theme-font-path` yourself — as with all `$theme-*` settings, HDS Core has already configured `uswds-core` by the time your stylesheet runs.
 
 ### Fixed header offsets
 

--- a/stories/overview/Installation.mdx
+++ b/stories/overview/Installation.mdx
@@ -130,7 +130,18 @@ To include USWDS utility classes:
 
 ### Vite: copy fonts and icons
 
-HDS Core's Sass source references fonts and icons with relative paths (`url('../assets/fonts/...')`). Vite cannot resolve these at compile time — you must copy the assets to the expected output location using `vite-plugin-static-copy`. See the [React guide](?path=/docs/guides-react-guidance--docs#sass-setup) for the full `vite.config.js` example. The same configuration applies to non-React Vite projects.
+HDS Core's Sass source references fonts and icons with relative paths (`url('../assets/fonts/...')`). Sass never rewrites `url()`, so those strings land verbatim in your compiled CSS and Vite cannot resolve them at compile time. You have two options:
+
+- **Copy the assets** next to your compiled CSS with `vite-plugin-static-copy`. One target covers everything: `node_modules/@nasa-hds/core/dist/assets` is a single complete tree (Inter, DM Mono, Public Sans, USWDS imagery, HDS icons, and `img/hds-sprite.svg`). See the [React guide](?path=/docs/guides-react-guidance--docs#sass-setup) for the full `vite.config.js` example. The same configuration applies to non-React Vite projects.
+- **Point HDS at your assets** by overriding `$hds-asset-path`, if you already serve static files from a fixed location:
+
+```scss
+@use '@nasa-hds/core/scss' with (
+  $hds-asset-path: '/static/hds-assets'
+);
+```
+
+Every emitted `url()` — webfonts, USWDS imagery, and HDS icons — is written relative to that base. `$hds-image-path` and `$hds-font-path` can be set individually if the two trees are served from different places.
 
 ### Using HDS tokens in Sass
 


### PR DESCRIPTION
## What this PR does

The published tarball shipped HDS's fonts and icons twice: `src/assets/` (120 files) was a strict, byte-identical subset of `dist/assets/`, which additionally carries Public Sans, the full USWDS img tree, and the generated sprite. Sass never rewrites `url()`, so `src/assets` was never resolved at compile time by anyone — its only published role was as a copy-source for docs. `dist/assets/` becomes the single canonical asset tree, and asset paths become adopter-configurable from Sass.

Closes #

## Type of change

- [ ] Bug fix (patch)
- [ ] New feature or component (minor)
- [x] Breaking change (see Public API section below)
- [ ] Documentation only
- [ ] Tooling or CI (no effect on published output)

Pre-1.0, so this is a **minor** bump per the [semver rubric](../CONTRIBUTING.md#semver-rubric).

### Changes

**`package.json`**
- `files`: dropped `src/assets/` → `["dist/", "src/scss/"]`
- exports: `"./assets": "./dist/assets/"` (deprecated trailing-slash form) → `"./assets/*": "./dist/assets/*"`
- exports: added `"./js/uswds": "./dist/js/uswds.min.js"` for the USWDS JS pass-through that already shipped but was not addressable. `./js` is deliberately **not** claimed — reserved for future HDS JavaScript.

**Public asset-path config** — three new variables in `_hds-config.scss` (public Sass surface):

```scss
$hds-asset-path: '../assets' !default;
$hds-image-path: '#{$hds-asset-path}/img' !default;
$hds-font-path: '#{$hds-asset-path}/fonts' !default;
```

All 14 hardcoded `'../assets/…'` sites in `src/scss` now route through them: `$theme-image-path`/`$theme-font-path` in **both** theme files (per AGENTS.md), and the icon `url()`s in `base/_content-rules.scss`, `_blockquote.scss`, `_link.scss`, `_accordion.scss`, `_table.scss` (×2), `_form.scss`, and `_navigation.scss` (×4). `_hds-config` is now `@use`d by both theme files and by each component that emits an icon url.

**Docs** — pointed consumers at `dist/assets`, collapsed the four `vite-plugin-static-copy` targets to one, fixed the sprite path, documented the override.

### One deviation worth flagging

The spec did not mention it, but `$hds-asset-path` was **not reachable** through the `./scss` entry point as specified: `hds.scss` only `@forward`s `hds-uswds-theme`, and that file `@use`s `hds-config` — a `@use` does not carry `with (…)` configuration up the chain, so `@use '@nasa-hds/core/scss' with ($hds-asset-path: …)` failed with *"This variable was not declared with `!default` in the `@used` module."* (This is a pre-existing gap: `$hds-enable-auto-dark-mode` and `$hds-enable-dataviz-tokens` were never adopter-configurable either, despite the snapshot listing them as public API.)

Fix: `@forward 'hds-config';` added to `hds.scss` and `hds-uswds.scss`, placed **before** the theme forward so adopter configuration lands before the theme reads `$hds-image-path`. Emits no CSS; compiled output is unchanged. As a side effect the two `$hds-enable-*` flags are now genuinely configurable, matching what the snapshot already promised. `hds-dataviz.scss` was left alone — it configures `hds-config` itself and emits no `url()`s.

## Checklist

- [x] `npm run format:fix` and `npm run lint:scss` pass
- [x] `npm run lint:js`, `lint:md`, `lint:mdx`, `lint:lockfile` pass
- [x] Tested across all 6 palettes in Storybook — N/A, compiled CSS is byte-identical
- [x] Tested across mobile, tablet, and desktop viewports — N/A, same
- [x] Automated a11y checks pass (`npm test`) — 29 files, 240 tests passed
- [x] Storybook documentation updated

`check:tokens`, `check:uswds`, `check:uswds-core`, `check:api-snapshot` all pass. `check:css-hash` is not in `package.json` on `main` yet (`ci/streamline-pipeline` has not merged), so the output gate was done manually — see below.

## Public API and changesets

- [x] Ran `npm run update:api-snapshot` and reviewed the diff
- [x] Changeset added with a prominent BREAKING-CHANGE notice
- [x] Bump level matches the semver rubric

Snapshot diff is **three additions, zero removals**:

```diff
 ## Sass Variables (_hds-config.scss)
+$hds-asset-path
 $hds-enable-auto-dark-mode
 $hds-enable-dataviz-tokens
+$hds-font-path
+$hds-image-path
```

### Breaking for adopters

1. **`src/assets/` is no longer published.** Copy from `dist/assets/` instead — one complete tree including `img/hds-sprite.svg`, Public Sans, and the USWDS imagery. Note the sprite is at `assets/img/hds-sprite.svg`, not `assets/hds-sprite.svg`.
2. **`./assets` → `./assets/*`.** Bare `@nasa-hds/core/assets` now fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`; individual files resolve (`@nasa-hds/core/assets/img/hds-sprite.svg`).

## Verification

### Compiled output is byte-identical

Built on the base branch, checksummed, applied the change, rebuilt:

```
dist/css/hds-dataviz.min.css: OK
dist/css/hds-uswds.min.css:   OK
dist/css/hds.min.css:         OK
```

`sha256sum -c` against the pre-change baseline, at the default config, with no baseline update. Re-verified after the `@forward` additions and again after `prepack`.

Stronger check on the Sass path: the override build's CSS is **byte-identical to the default build's** after mechanically un-substituting the path prefix — the override is a pure path swap, nothing else moved.

### Tarball audit (`npm pack`)

|                    | before | after | delta |
| ------------------ | -----: | ----: | ----: |
| files              | 2,760 | 2,640 | **−120** |
| packed bytes       | 4,197,271 | 3,026,030 | **−1,171,241 (−27.9%)** |
| unpacked bytes     | 7,314,577 | 5,957,269 | −1,357,308 (−18.6%) |

`npm pack --dry-run` shows zero `src/assets/` entries; installed `src/` contains only `scss`.

### Install-test — both consumption paths, from a real tarball

Packed and installed into throwaway projects outside the repo.

**1. Link-tag path.** Minimal HTML page `<link>`ing the installed `dist/css/hds.min.css`, served statically, loaded in Chromium with request capture and `document.fonts.load()` forcing the webfonts. **13 asset requests, all `200`, all resolved inside the installed package** via `../assets/…` — 6 fonts (Inter, DM Mono, Public Sans), 6 HDS icons, and the sprite. Zero failures or 4xx.

Statically, all **65** distinct asset references in the installed `hds.min.css` (26 font, 39 img) resolve to real files relative to `dist/css/` — 0 unresolved. The other two bundles emit no `url()`s.

**2. Sass path.** Vite project with `@use '@nasa-hds/core/scss'` resolved through the exports map, compiled twice:

| | url() total | file refs | conforming |
| --- | ---: | ---: | ---: |
| default (`'../assets'`) | 193 | 131 | **131 / 131** |
| override (`'/static/hds-assets'`) | 193 | 131 | **131 / 131** |

Both include the 26 USWDS-emitted `@font-face` urls across all three families (`dm-mono`, `inter`, `public-sans`) and all 7 HDS icon urls — including the two `_navigation.scss` chevrons and the `_content-rules.scss` quote. **Zero non-conforming urls** under the override. This also confirms the fonts question: there are no hand-written `@font-face` declarations in `src/scss`, and routing the two theme variables does cover them.

**3. Exports map**, probed against the installed tarball:

```
OK    @nasa-hds/core/css, /css/uswds, /css/dataviz
OK    @nasa-hds/core/scss, /scss/uswds, /scss/dataviz
OK    @nasa-hds/core/js/uswds                    -> dist/js/uswds.min.js
OK    @nasa-hds/core/assets/img/hds-sprite.svg   -> dist/assets/img/hds-sprite.svg
OK    @nasa-hds/core/assets/fonts/inter/Inter-Regular.woff2
FAIL  @nasa-hds/core/assets                      -> ERR_PACKAGE_PATH_NOT_EXPORTED  (expected)
```

## Research: how comparable USWDS-based systems ship assets

Context-gathering only — **no code change in this PR.** Measured from the actual published tarballs rather than docs.

| System | Published assets | Re-ships USWDS img tree? | Pattern |
| --- | --- | :-: | --- |
| **USWDS** `@uswds/uswds` 3.13.0 | 4,190 entries / 18.4 MB. `dist/img` = 2,526 files (2,122 `material-icons`, 245 `usa-icons`, 24 `uswds-icons`, 19 `usa-icons-bg`, 9 favicons, 22 root) + `dist/img/sprite.svg`. `dist/fonts` = 144 files, 4 families, eot/ttf/woff/woff2 | — (source) | Ships everything. Its own `@uswds/compile` copies `dist/img/**` and `dist/fonts/**` **wholesale** into the consumer's project |
| **login.gov** `identity-style-guide` 6.7.0 | 2,442 entries / 9.3 MB. `dist/assets/img/material-icons` (1,520) + `usa-icons` (241) + `uswds-icons` + `usa-icons-bg` + favicons + 82 root; all 4 USWDS font families | **Yes** | **Same pattern as HDS** — re-ships the whole tree under `dist/assets` |
| **VADS** `css-library` 0.33.1 | 161 entries / 3.1 MB. 41 img + 66 font files. `files` uses deliberately flat single-level globs: `dist/fonts/*`, `dist/img/*` | No | Takes `@uswds/uswds@3.10.0` as a **build** dependency, ships a hand-curated flat set of only what its own CSS references |
| **VADS** `component-library` 56.9.0 | 357 entries. Assets = **`dist/img/sprite.svg`** and nothing else | No | Sprite-only; fonts delegated to `css-library` |
| **CMSDS** `@cmsgov/design-system` 18.0.1 | 1,973 entries. 7 font files, **zero img tree**; ~41 icons shipped as per-icon web components × 5 module formats | No | Icons-as-code, not files to deploy |
| **`@trussworks/react-uswds`** 11.2.0 | 188 entries. **Zero assets** (`files: ["lib"]`) | No | Leaves assets entirely to the consumer; `@uswds/uswds` is a `peerDependency` |

**Is HDS typical?** Yes — and it has a direct precedent. login.gov's `identity-style-guide` does exactly what HDS does, and USWDS's own official tooling copies the tree wholesale, so "re-ship everything" is the sanctioned default. But HDS is at the heavy end: the two systems whose teams treated the design system as a *library* (VADS, CMSDS) both curate down to what their CSS actually references.

**Worth a future trim? Yes, but for file count, not bytes.** One correction to the premise: `dist/assets` is **3.07 MiB**, not ~13 MB. The 13 MB figure is `du` block allocation across 2,585 mostly sub-kilobyte files; `du --apparent-size` gives 3.1 MB.

| group | files | MiB | % bytes |
| --- | ---: | ---: | ---: |
| `fonts/inter` | 11 | 1.12 | 36.5% |
| `img/material-icons` | 2,122 | 0.69 | 22.5% |
| `fonts/public-sans` | 18 | 0.56 | 18.2% |
| `img/` (root files) | 23 | 0.41 | 13.2% |
| everything else | 411 | 0.29 | 9.6% |

`hds.min.css` references only **65 of 2,585 files** — 2.5% of files but 54% of bytes (the fonts dominate). Excluding `material-icons` + `material-icons-deprecated` would drop **2,127 of 2,585 files (−82%)** but save only ~283 KB packed, ~9% of the 3.03 MB tarball. The win is install-time syscalls, CI cache size, and container layers — not download size. Trimming fonts would be the byte win, but they're all referenced and needed.

There is a decent architectural argument for the trim: per `@uswds/compile`'s docs, `material-icons` exists in USWDS's tree as a **design-time palette to pick sprite icons from** ("Add icons (typically from either `uswds-icons` or `material-icons`) to this directory"), not as a runtime asset set — and HDS already ships its own generated `hds-sprite.svg`. Caveat for whoever picks this up: an adopter using `.usa-icon` with a material-icon id, or copying `material-icons` into their own sprite build per the USWDS docs, would break — so it wants a minor bump with a deprecation note, not a silent trim. Flagging as a separate future decision, per scope.

## Visual review

N/A — compiled CSS is byte-identical to `main`. No visual change is possible at the default config.

## Notes for reviewers

- **`_navigation.scss` is a protected stub.** Touched only for the mechanical `'../assets'` → `#{$hds-image-path}` substitution (4 sites) plus the `@use 'hds-config'` line that substitution requires, per the maintainer's explicit grant. No other edits. `_banner.scss` contains no `../assets` strings and is untouched.
- **`dist/js/uswds-init.min.js` still ships but is not exported**, matching today's behavior. Question for you: do USWDS-JS consumers need the init script addressable as e.g. `./js/uswds-init`? Not added unasked.
- **Two drive-by doc fixes** in blocks I was already rewriting: `ReactSetup.mdx` had a duplicated `loadPaths` key in the `vite.config.js` example (invalid as an object literal), and README's "What Ships" listed `js/uswds.js` where the package ships `uswds.min.js`. The README tree was already dist-only and needed no `src/assets` correction.
- **`SassConfiguration.mdx` was self-contradictory** and is now fixed: it stated `$theme-*` variables cannot be overridden from consumer stylesheets, then listed `$theme-image-path`/`$theme-font-path` under "Settings you may need to adjust". That table is now the three `$hds-*` variables, which genuinely are configurable, with a note not to reach for the USWDS ones.
- References to `src/assets` as an **in-repo build input** were left alone as correct: `copy:hds` and `sprite` in `package.json`, `stories/helpers/icons.js` comments, and `src/assets/**` in `.config/chromatic.config.json` externals.
- The a11y suite needed a local workaround to run here — this environment has Playwright browser build 1194 while the pinned Playwright wants 1228. Symlinked outside the repo; no repo change, and all 240 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqxAph4VW2Jc3Fr2MswCi4)_