### PR TITLE
fix: stop HDS accordion restyle leaking into USWDS banner/nav toggles

### DIFF
--- a/.changeset/lucky-owls-guard.md
+++ b/.changeset/lucky-owls-guard.md
@@ -1,0 +1,9 @@
+---
+'@nasa-hds/core': patch
+---
+
+Stop the HDS accordion restyle from leaking into the USWDS banner and nav
+
+USWDS reuses the `.usa-accordion*` classes outside real accordions: the government banner's "Here's how you know" toggle and the primary nav's dropdown behavior (including the mobile drawer) are both built on them. The HDS accordion restyle (borderless container, flush headings, circled chevron) was reaching those toggles and misplacing their icons. The overrides in `components/_accordion.scss` are now guarded with `:not(.usa-banner *):not(.usa-nav *)`, so the HDS treatment applies only to genuine accordions and the banner and nav toggles render as stock USWDS.
+
+This is a stopgap until the nav and banner get real HDS theming (Issue #86).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,6 +319,10 @@ Selectors are wrapped in `:where()` so their specificity is zero. An adopter who
 
 These are a stopgap. Remove them when the components get real HDS theming.
 
+### USWDS accordion-class guard
+
+USWDS reuses the `.usa-accordion*` classes outside real accordions — for the banner's "Here's how you know" toggle and the primary nav's dropdown behavior. The HDS accordion restyle (circled chevron, heading treatment) leaked into both, misplacing the toggle icon. The overrides in `components/_accordion.scss` are therefore guarded with `:not(.usa-banner *):not(.usa-nav *)` so the HDS treatment applies only to genuine accordions and leaves the banner and nav toggles as bare USWDS. Remove the guard once those components get real HDS theming.
+
 ## Testing
 
 | Script                | Purpose                                     |

--- a/src/scss/components/_accordion.scss
+++ b/src/scss/components/_accordion.scss
@@ -29,17 +29,26 @@
 @use 'hds-tokens' as *;
 @use 'hds-mixins' as *;
 
+// ── Scope guard ───────────────────────────────────────────────
+// USWDS reuses the .usa-accordion / .usa-accordion__button /
+// .usa-accordion__content classes inside its Banner ("Here's how
+// you know" toggle) and Nav (.usa-nav__primary.usa-accordion,
+// including the mobile drawer submenus). Our HDS Accordion style
+// (borderless, flush headings, circled chevron) must not reach
+// them; it misplaced the banner/nav toggle icon. See Issue #86.
+$_accordion-guard: ':not(.usa-banner *):not(.usa-nav *)';
+
 // ── Container ─────────────────────────────────────────────────
 // Remove USWDS left border
 
-.usa-accordion {
+.usa-accordion#{$_accordion-guard} {
   border-left: 0;
 }
 
 // ── Separator line ────────────────────────────────────────────
 // Between items only, not first or last
 
-.usa-accordion__heading {
+.usa-accordion__heading#{$_accordion-guard} {
   border-top: 1px solid var(--hds-palette-border, #{$hds-color-carbon-20});
 
   // Override USWDS margin-top: units(1) on :not(:first-child) so adjacent
@@ -47,14 +56,14 @@
   margin: 0;
 }
 
-.usa-accordion > .usa-accordion__heading:first-child {
+.usa-accordion#{$_accordion-guard} > .usa-accordion__heading:first-child {
   border-top: 0;
 }
 
 // ── Heading button ────────────────────────────────────────────
 // Transparent, palette-aware, circled chevron
 
-.usa-accordion__button {
+.usa-accordion__button#{$_accordion-guard} {
   // Override USWDS set-text-and-bg mixin
   background-color: transparent;
   color: var(--hds-palette-heading, #{$hds-color-carbon-black});
@@ -137,7 +146,7 @@
 // ── Content area ──────────────────────────────────────────────
 // Transparent, palette-aware text, no top border
 
-.usa-accordion__content {
+.usa-accordion__content#{$_accordion-guard} {
   background-color: transparent;
   color: var(--hds-palette-text, #{$hds-color-carbon-90});
   border-top: 0;


### PR DESCRIPTION
## What this PR does

USWDS reuses the `.usa-accordion*` classes outside real accordions: the government banner's "Here's how you know" toggle and the primary nav dropdown (including the mobile drawer) are both built on them. The HDS accordion restyle (borderless container, flush headings, circled chevron) was leaking into those toggles, rendering a doubled/misplaced chevron (one landing on top of the label instead of beside it) even in the collapsed state. This guards the overrides in `components/_accordion.scss` with `:not(.usa-banner *):not(.usa-nav *)` so the HDS treatment applies only to genuine accordions; the banner and nav toggles now render as stock USWDS. Stopgap until nav and the banner get real HDS theming.

Follow-up to #160.

Relates to #86

## Type of change

<!-- Check one. -->

- [x] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API section below)
- [ ] Documentation only
- [ ] Tooling or CI (no effect on published output)

## Checklist

- [x] `npm run format:fix` and `npm run lint:scss:fix` pass
- [x] `npm run lint:js` and `npm run lint:md` pass
- [x] Tested across all 6 palettes in Storybook
- [x] Tested across mobile, tablet, and desktop viewports
- [x] Automated a11y checks pass (`npm test`)
- [x] Storybook documentation updated (if component changed)

## Public API and changesets

- [x] Ran `npm run update:api-snapshot` and reviewed the diff
- [x] Changeset added (`npx changeset`) with appropriate bump level
- [x] Bump level matches the [semver rubric](../CONTRIBUTING.md#semver-rubric)

<!-- Snapshot unchanged: the guard adds `:not(...)` to existing `.usa-accordion*` selectors but adds/removes no public class names. Bump is `patch`: this fixes unintended leaked styling (no adopter could rely on it), not an intentional restyle, so the "visual restyling" rule (CONTRIBUTING.md:153) does not apply. -->

## Visual review

Confirmed via Chromatic (accepted). Stories to check:

- **Guides / USWDS Documentation** and **Guides / USWDS Landing Page** — banner "Here's how you know" toggle and primary nav chevrons should render as bare USWDS (single, correctly placed chevron).

Before:
<img width="446" height="98" alt="before image" src="https://github.com/user-attachments/assets/5cbcc9a3-0ec7-4785-98e7-1dd223823939" />

After:
<img width="377" height="72" alt="after image" src="https://github.com/user-attachments/assets/aa07b0d4-ef7a-49ef-a434-8bbf0b6eda40" />

- **Components / Accordion** — genuine HDS accordions should still show the circled chevron and flush-heading restyle.

## Notes for reviewers

The `_palettes.scss` surface bridges and the identifier/header/footer/banner pins are already on `main` via #160 and are intentionally untouched here. This PR is strictly the accordion-class guard. The `.usa-nav` mobile-drawer legibility was checked and is fine on `main`, so no nav palette pin was added.