### PR TITLE
chore: share VS Code editor config for relocated .config/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 /node_modules/
 /dist/
 /assets/
-/.vscode/
+/.vscode/*
+!/.vscode/settings.json
+!/.vscode/extensions.json
 *.css.map
 *storybook.log
 storybook-static

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "stylelint.vscode-stylelint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,27 @@
+{
+  "prettier.configPath": ".config/prettierrc.json",
+  "prettier.ignorePath": ".config/prettierignore",
+
+  "stylelint.configFile": ".config/stylelintrc.json",
+  "stylelint.ignorePath": ".config/stylelintignore",
+  "stylelint.validate": ["css", "scss"],
+
+  "[mdx]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
## What this PR does

The Prettier and Stylelint VS Code extensions auto-discover their config only from the repo root. Moving the configs into `.config/` silently broke on-save formatting (MDX started flipping single quotes to double) and in-editor SCSS linting. This adds a shared `.vscode/settings.json` pointing both extensions at `.config/`, plus a recommended-extensions file so teammates get prompted to install the extensions the settings target.

No effect on published output; the `format:fix` / `lint:scss:fix` CLI scripts remain the opt-out for anyone who prefers not to have editor automation.

## Type of change

- [ ] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API section below)
- [ ] Documentation only
- [x] Tooling or CI (no effect on published output)

## Checklist

- [x] `npm run format:fix` and `npm run lint:scss:fix` pass
- [x] `npm run lint:js` and `npm run lint:md` pass
- [ ] Tested across all 6 palettes in Storybook
- [ ] Tested across mobile, tablet, and desktop viewports
- [ ] Automated a11y checks pass (`npm test`)
- [ ] Storybook documentation updated (if component changed)

<!-- Palette/viewport/a11y/story rows are N/A: this PR touches only editor tooling, not shipped SCSS or stories. -->

## Public API and changesets

Does not touch `src/scss/**` — no snapshot change, no changeset. (Editor tooling only.)

## Visual review

N/A

## Notes for reviewers

- `settings.json` also pins `stylelint.ignorePath` to `.config/stylelintignore`: setting `stylelint.configFile` disables the extension's automatic `.stylelintignore` discovery ([vscode-stylelint #553](https://github.com/stylelint/vscode-stylelint/issues/553)), so the ignore path must be set explicitly.
- `.gitignore` un-ignores only `settings.json` and `extensions.json` under `.vscode/`; everything else in that dir stays ignored.