### PR TITLE
docs: correct drifted gzipped bundle sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Exposes HDS tokens, mixins, and USWDS core utilities for use in your own Sass pi
 
 | File                  | Size   | Notes                                     |
 | --------------------- | ------ | ----------------------------------------- |
-| `hds.min.css`         | 43 KB  | Required; HDS/USWDS styles and components |
-| `hds-uswds.min.css`   | 48 KB  | Optional; USWDS utility classes           |
+| `hds.min.css`         | 48 KB  | Required; HDS/USWDS styles and components |
+| `hds-uswds.min.css`   | 49 KB  | Optional; USWDS utility classes           |
 | `hds-dataviz.min.css` | 1.2 KB | Optional; HDS data visualization styles   |
 
 ## Contributing to HDS Core

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,8 +92,8 @@ hds-core/
 
 | Bundle | Contents | Gzipped | Who loads it |
 | --- | --- | --- | --- |
-| `hds.min.css` | All USWDS components + HDS base + HDS components | 43 KB | Everyone |
-| `hds-uswds.min.css` | USWDS utility classes (`.padding-*`, `.margin-*`, etc.) | 48 KB | Sites using USWDS utilities |
+| `hds.min.css` | All USWDS components + HDS base + HDS components | 48 KB | Everyone |
+| `hds-uswds.min.css` | USWDS utility classes (`.padding-*`, `.margin-*`, etc.) | 49 KB | Sites using USWDS utilities |
 | `hds-dataviz.min.css` | Data visualization color palettes | 1.2 KB | Sites rendering charts; standalone-capable |
 
 Vanilla USWDS reference: 73 KB (all components + utilities, no HDS theming).


### PR DESCRIPTION
## What this PR does

Corrects the gzipped bundle-size figures in `README.md` and `docs/ARCHITECTURE.md`, which had drifted from the actual built output (flagged in review). Measured from a fresh build on `main`.

Closes #

| Bundle | Was | Now (gzip) |
| --- | --- | --- |
| `hds.min.css` | 43 KB | **48 KB** |
| `hds-uswds.min.css` | 48 KB | **49 KB** |
| `hds-dataviz.min.css` | 1.2 KB | 1.2 KB (unchanged) |

## Type of change

- [ ] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API note below)
- [x] Documentation only
- [ ] Tooling or CI (no effect on published CSS)

## How to review

N/A (docs-only). Numbers came from `npm run build` on current `main` + `gzip -c dist/css/*.min.css | wc -c`.

## Before requesting review

- [x] `npm run lint`, `npm run format`, and `npm test` pass locally
- [ ] Checked across all 6 palettes in Storybook
- [ ] Checked across mobile, tablet, and desktop viewports
- [ ] Automated a11y checks pass and I've done a manual a11y pass (keyboard, focus, screen-reader labels)
- [ ] **If it touches `src/scss/**`:** added a changeset

No `src/scss/**` changes, so no changeset required.

## Notes for reviewers

The 73 KB "vanilla USWDS reference" line in ARCHITECTURE.md was left as-is; it's an external comparison baseline, not something our build produces, so it wasn't re-measured here. A follow-up will replace the hardcoded figures with a live size badge once v0.9.0 is on npm.