### PR TITLE
fix: map USWDS hero callout and dark sections onto the HDS dark palette

### DIFF
--- a/.changeset/tidy-berries-repeat.md
+++ b/.changeset/tidy-berries-repeat.md
@@ -1,0 +1,11 @@
+---
+'@nasa-hds/core': minor
+---
+
+USWDS hero callouts and dark sections now render on the HDS dark surface instead of a NASA-red block.
+
+`.usa-hero__callout` and `.usa-section--dark` paint their own background in USWDS, using the primary color and cyan headings. Under the HDS theme that produced a dark red block with cyan headings, a red call-to-action sitting on the red hero box, and HDS components inside the section still using white-palette colors — white text was fine, but links and outline buttons came out near-black on red. A `.hds-palette-*` wrapper could not correct any of it, because the red is a background on the component itself.
+
+Both surfaces now use the HDS dark palette, so headings, text, links, buttons, and focus rings inside them match the surface they sit on. No markup changes are needed. To put one of these sections on a different surface, add a palette class to the same element (`class="usa-section usa-section--dark hds-palette-blue"`).
+
+If your site relied on the red hero callout or red dark section, this is a visible change — review those pages after upgrading.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,14 @@ color: var(--hds-palette-link-text, #{$hds-color-carbon-90});
 - Do not remove the explicit `background-color` — `.usa-header` and `.usa-footer` have none of their own.
 - Remove the bridges only when the components get real HDS theming.
 
+### USWDS dark contexts — do NOT flatten
+
+`base/_palettes.scss` also maps `.usa-hero__callout` and `.usa-section--dark` onto the dark palette. USWDS fills both with `primary-darker` (NASA Red under the HDS theme) and colors their headings `accent-cool` (cyan), neither of which a palette wrapper can reach.
+
+- Apply the full `_scheme-dark`, not just a background. Components inside read `--hds-palette-*`; a background-only fix leaves them on light-palette values.
+- Keep `:where()` here too, for the same override contract.
+- These are not a stopgap. Change them only on a design call — see Issue #148 and docs/DESIGN.md → USWDS Dark Contexts.
+
 ### Class naming
 
 - `usa-*` for components that map to a USWDS component (even if they have HDS-only variants).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 Technical decisions by maintainers and conventions for contributors.
 
-Last updated: 2026-07-25
+Last updated: 2026-07-27
 
 ## Package Overview
 
@@ -318,6 +318,26 @@ The bridges set `background-color` as well as the palette custom properties, bec
 Selectors are wrapped in `:where()` so their specificity is zero. An adopter who wants a different surface adds a `.hds-palette-*` class to the same element and wins without `!important`. A palette wrapper on an _ancestor_ does not win: a declaration on the element always beats an inherited value, which is what keeps the bridge in force.
 
 These are a stopgap. Remove them when the components get real HDS theming.
+
+### USWDS dark context surfaces
+
+USWDS paints two layout contexts dark on their own: the hero callout and `.usa-section--dark` (the surface the graphic list sits on in the landing page template). Both use `color("primary-darker")`, which the HDS theme maps to NASA Red, and both color their headings `color("accent-cool")`, a family HDS never themes. A palette wrapper cannot reach either value — the red is a `background-color` on the component, not a custom property.
+
+`base/_palettes.scss` maps both onto palette 4 (dark, Carbon 90):
+
+| Selector | Palette applied | What it corrects |
+| --- | --- | --- |
+| `.usa-hero__callout` | Dark | Red callout box, cyan heading, red CTA on red |
+| `.usa-section--dark` | Dark | Red section band, cyan headings, light-palette components inside |
+| `.usa-hero__heading--alt` | — | Takes `--hds-palette-muted` so the eyebrow stays distinct from the heading |
+
+Applying the full dark scheme, not just a background, is what makes components inside the section correct: `.usa-link`, `.usa-button--outline`, and focus rings all read `--hds-palette-*` values, which previously resolved against whatever palette wrapped the page.
+
+Selectors use `:where()`, so specificity stays at zero and `.hds-palette-*` on the same element still wins — the same contract as the surface bridges above. These rules override USWDS by cascade layer, not specificity: `hds-base` outranks `uswds` regardless of how the two selectors compare.
+
+`base/_print.scss` lists both selectors alongside the palette containers. Browsers drop background colors when printing, so a dark surface that keeps its white text prints as blank paper. The print reset also has to override USWDS's white `<p>` and `<a>` inside `.usa-section--dark` directly, because those are set on the children and only reached by inheritance otherwise.
+
+Unlike the surface bridges, these are not a stopgap for missing theming. They stay in place unless the design direction for dark sections changes. See DESIGN.md for the color decisions and contrast figures.
 
 ### USWDS accordion-class guard
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -4,7 +4,7 @@ Visual and UX decisions for the HDS creative director, designers, and design-min
 
 For implementation architecture, see ARCHITECTURE.md. For Storybook documentation conventions, see DOCUMENTATION.md. For implementation details (token values, contrast ratios, typography specs), see the SCSS source files — code comments are the single source of truth for "what values does this use."
 
-Last updated: 2026-07-25
+Last updated: 2026-07-27
 
 ## Class Naming Convention
 
@@ -50,6 +50,29 @@ HDS Core uses exact HDS hex values for all component styles. USWDS utility class
 ### Link Colors
 
 HDS links use body text color — not brand color — for the text itself. The dashed underline and external arrow provide the visual affordance. This prevents bare `<a>` tags from rendering in NASA Red after the primary/secondary swap.
+
+### USWDS Dark Contexts
+
+USWDS fills its two dark layout contexts — the hero callout (`.usa-hero__callout`) and `.usa-section--dark`, which the graphic list sits on — with `color("primary-darker")`, and colors the headings inside them with `color("accent-cool")`. HDS themes the primary family to NASA Red and never themes accent-cool, so both surfaces rendered as a dark red block with cyan headings, with a red `.usa-button` on the red hero callout.
+
+A `.hds-palette-*` wrapper could not correct this. The red is a `background-color` on the component itself, not a palette custom property, and a wrapper actually made the headings worse: inside `.hds-palette-white` they resolved to Carbon Black on the red block.
+
+Both surfaces are now mapped onto palette 4 (dark, Carbon 90) in `base/_palettes.scss`. That reuses a surface HDS already designed rather than inventing a new one, and everything inside — headings, body text, links, buttons, focus rings — resolves against the surface it is actually sitting on.
+
+| What | Before | After |
+| --- | --- | --- |
+| Hero callout and dark section background | USWDS `primary-darker` `#8b0a03` | Carbon 90 `#17171b` |
+| Headings on those surfaces | USWDS `accent-cool` `#00bde3` (4.38:1) | `--hds-palette-heading` white (17.9:1) |
+| Hero `--alt` eyebrow | White, indistinguishable from the heading once the cyan is dropped | `--hds-palette-muted` Carbon 30 (9.1:1) |
+| `.usa-link` inside a dark section | Carbon 90 on the red block (1.8:1) | White (17.9:1) |
+| `.usa-button--outline` label inside a dark section | Carbon Black on the red block (2.1:1) | White (17.9:1) |
+| `.usa-button` on the hero callout | `#d83933` on `#8b0a03` (2.1:1 against its container) | `#d83933` on Carbon 90 (3.9:1) |
+
+USWDS also pins `<p>` and `<a>` inside `.usa-section--dark` to white. Those declarations are left alone: white is what the dark scheme resolves to, and the blue palette — the other surface an adopter would plausibly swap in on a section marked dark — is also a dark surface with white body text.
+
+`.usa-section--light` is untouched. USWDS paints it `base-lightest`, which the HDS theme maps to white, so it already agrees with the default palette.
+
+Tracked in [Issue #148](https://github.com/nasa/hds-core/issues/148). See ARCHITECTURE.md for the cascade contract.
 
 ### Data Visualization Color Alignment
 
@@ -466,6 +489,7 @@ Pending visual sign-offs:
 
 | Item | Question | Context |
 | --- | --- | --- |
+| USWDS dark contexts | Is the HDS dark palette (Carbon 90) the right surface for the USWDS hero callout and `.usa-section--dark`, or should a red hero be a deliberate NASA treatment? And should the hero's `--alt` eyebrow stay muted Carbon 30 rather than matching the heading white? | Issue #148. Shipping the dark palette mapping; every value is an existing palette token, so a different call is a one-line change in `base/_palettes.scss`. |
 | Focus bold on light backgrounds | C30 on white/light/midtone fails WCAG 1.4.11 (3:1 non-text contrast). Should bold focus treatment use a darker value on light backgrounds? | Tracked in Issue #40. Ships as Figma spec for now. |
 | Overline font-weight | Should overline use 400 (Proposal) or 500 (Figma)? | Proposal says "normal" (400). Figma uses Medium (500). Currently shipping 500. |
 | Blue palette utility | Blue palette utility now uses Proposal palette 5 values (Carbon Black fill, Carbon 60 stroke — matching dark scheme). Figma shows NASA Blue fill + Blue Tint stroke. | Currently shipping Proposal values. Flagged in case CD prefers Figma treatment. |

--- a/public-api.snapshot.txt
+++ b/public-api.snapshot.txt
@@ -474,6 +474,8 @@ hds-type-classes
 .usa-form-group--disabled
 .usa-form-group--error
 .usa-header
+.usa-hero__callout
+.usa-hero__heading--alt
 .usa-hint
 .usa-icon
 .usa-identifier
@@ -513,6 +515,7 @@ hds-type-classes
 .usa-radio__label
 .usa-radio__label-description
 .usa-section
+.usa-section--dark
 .usa-select
 .usa-sidenav
 .usa-sidenav__item

--- a/src/scss/base/_palettes.scss
+++ b/src/scss/base/_palettes.scss
@@ -16,6 +16,7 @@
 //   Shared Color Schemes
 //   Palettes
 //   USWDS Surface Bridges
+//   USWDS Dark Context Surfaces
 //   Auto Dark Mode
 // ============================================================
 
@@ -336,6 +337,72 @@
   --hds-palette-bg: #{$hds-color-carbon-black};
 
   background-color: var(--hds-palette-bg);
+}
+
+// ============================================================
+// USWDS DARK CONTEXT SURFACES
+// ============================================================
+// USWDS paints its two dark layout contexts — the hero callout
+// and .usa-section--dark (which the graphic list sits on in the
+// USWDS landing page template) — with color("primary-darker"),
+// and colors the headings inside them with color("accent-cool").
+//
+// HDS themes the primary family to NASA Red, so both surfaces
+// come out as a dark red block, and accent-cool is a family HDS
+// never themes, so the headings come out USWDS cyan. Neither
+// color is in the HDS palette. The red block also puts a red
+// .usa-button on a red background, roughly 2.1:1 apart.
+//
+// A .hds-palette-* wrapper cannot correct this: the red is a
+// background-color on the component itself, not a palette
+// custom property, so it survives any wrapper (Issue #148).
+//
+// HDS already has a designed dark surface — palette 4, Carbon
+// 90 — so each USWDS dark context is mapped onto it. Text,
+// headings, links, buttons, and focus rings inside resolve
+// against the surface they actually sit on, which is the same
+// guarantee .hds-palette-dark gives, without asking adopters to
+// add a class to markup they already have.
+//
+// USWDS also pins <p> and <a> inside .usa-section--dark to
+// white. Those are left as they are: white is what the dark
+// scheme resolves to, and the blue palette — the other surface
+// an adopter would plausibly swap in here — is also a dark
+// surface with white body text.
+//
+// :where() holds specificity at zero, so an adopter who wants a
+// different surface adds .hds-palette-* to the same element and
+// wins without !important — same contract as the surface
+// bridges above.
+// ============================================================
+
+:where(.usa-hero__callout, .usa-section--dark) {
+  @include _scheme-universal;
+  @include _scheme-dark;
+
+  --hds-palette-bg: #{$hds-color-carbon-90};
+
+  background-color: var(--hds-palette-bg);
+  color: var(--hds-palette-text);
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: var(--hds-palette-heading);
+  }
+}
+
+// The USWDS hero heading is two-tone: an --alt eyebrow set above
+// the statement itself. Painting both with the heading color
+// would flatten that, so the eyebrow takes the muted token HDS
+// already uses for overlines and metadata (Carbon 30, 9.1:1 on
+// Carbon 90). Flagged for creative director review in
+// docs/DESIGN.md.
+:where(.usa-hero__callout) .usa-hero__heading--alt {
+  color: var(--hds-palette-muted);
 }
 
 // ============================================================

--- a/src/scss/base/_print.scss
+++ b/src/scss/base/_print.scss
@@ -6,10 +6,16 @@
 // ============================================================
 
 @media print {
-  // Reset all palettes to high-contrast light
+  // Reset all palettes to high-contrast light.
+  // The USWDS dark contexts (base/_palettes.scss) are listed here
+  // too: they carry the dark scheme without being palette
+  // containers, and browsers drop background colors when printing,
+  // so their white text would come out as blank paper.
   :root,
   [data-hds-palette],
-  [class*='hds-palette-'] {
+  [class*='hds-palette-'],
+  .usa-hero__callout,
+  .usa-section--dark {
     --hds-palette-bg: #ffffff !important;
     --hds-palette-heading: #000000 !important;
     --hds-palette-text: #000000 !important;
@@ -20,6 +26,13 @@
     --hds-palette-icon: #000000 !important;
 
     background-color: #ffffff !important;
+    color: #000000 !important;
+  }
+
+  // USWDS pins paragraphs and links inside .usa-section--dark to
+  // white on the elements themselves, so the reset above only
+  // reaches them by inheritance and loses.
+  .usa-section--dark :is(p, a) {
     color: #000000 !important;
   }
 

--- a/stories/guides/USWDS.mdx
+++ b/stories/guides/USWDS.mdx
@@ -193,4 +193,4 @@ Settings not reserved by HDS Core continue to work. See the [Sass Configuration 
 
 ## Live preview
 
-Use the **Documentation**, **Landing Page**, and **Multi-Step Form** stories in the sidebar to see unmodified USWDS template markup rendered under the HDS Core theme. **Dark Sections** shows the hero callout and dark section on their own, which is the quickest way to check how your own dark markup will land.
+Use the **Documentation**, **Landing Page**, and **Multi-Step Form** stories in the sidebar to see unmodified USWDS template markup rendered under the HDS Core theme. [**Dark Sections**](?path=/story/guides-existing-uswds-site-dark-sections--dark-sections) shows the hero callout and dark section on their own, which is the quickest way to check how your own dark markup will land.

--- a/stories/guides/USWDS.mdx
+++ b/stories/guides/USWDS.mdx
@@ -52,20 +52,28 @@ After installing, review the following to bring your site into HDS's intended vi
 
 HDS Core uses a palette system activated through `.hds-palette-*` wrapper classes. When no palette class is set, HDS applies its default white palette.
 
-**USWDS's `.usa-section--dark` does not activate the HDS dark palette.** A section marked `.usa-section--dark` will render with a dark background and white base text, but HDS components placed inside will still inherit white-palette custom properties. This can produce contrast failures, such as light-mode buttons on a dark background.
+**Two USWDS dark contexts are handled for you.** A hero callout (`.usa-hero__callout`) and a section marked `.usa-section--dark` render on the HDS dark surface, and the headings, text, links, and buttons inside them follow. Your markup does not change. In vanilla USWDS these two contexts paint themselves with the primary color, which under HDS would put them in NASA red.
 
-To activate the full HDS dark palette, add `.hds-palette-dark` to the same element or a parent wrapper:
+To put one of them on a different surface, add a palette class to the same element:
+
+```html
+<section class="usa-section usa-section--dark hds-palette-blue">
+  <!-- renders on the blue surface instead of the dark one -->
+</section>
+```
+
+**Every other dark context still needs a palette class.** `.usa-dark-background`, background utility classes, and your own dark wrappers give you a dark background, but HDS components inside them still use white-palette colors. This can produce contrast failures, such as light-mode buttons on a dark background. Add `.hds-palette-dark` to the element or a parent wrapper:
 
 ```html
 <!-- Before -->
-<section class="usa-section usa-section--dark">
+<div class="usa-dark-background">
   <!-- components render with white-palette values -->
-</section>
+</div>
 
 <!-- After -->
-<section class="usa-section hds-palette-dark">
+<div class="usa-dark-background hds-palette-dark">
   <!-- components render with dark-palette values -->
-</section>
+</div>
 ```
 
 Review every page for dark-mode markup and add palette classes accordingly. This is the most common source of visual issues during adoption.
@@ -185,4 +193,4 @@ Settings not reserved by HDS Core continue to work. See the [Sass Configuration 
 
 ## Live preview
 
-Use the **Documentation**, **Landing Page**, and **Multi-Step Form** stories in the sidebar to see unmodified USWDS template markup rendered under the HDS Core theme.
+Use the **Documentation**, **Landing Page**, and **Multi-Step Form** stories in the sidebar to see unmodified USWDS template markup rendered under the HDS Core theme. **Dark Sections** shows the hero callout and dark section on their own, which is the quickest way to check how your own dark markup will land.

--- a/stories/guides/USWDSDarkSections.stories.js
+++ b/stories/guides/USWDSDarkSections.stories.js
@@ -80,6 +80,7 @@ const graphicList = `
 
 export const DarkSections = {
   name: 'Hero and dark section',
+  tags: ['!dev'],
   render: () => `${hero}${graphicList}`,
 };
 

--- a/stories/guides/USWDSDarkSections.stories.js
+++ b/stories/guides/USWDSDarkSections.stories.js
@@ -1,0 +1,91 @@
+// ============================================================
+// USWDS Dark Sections — Surface Mapping Check
+// ============================================================
+// The two USWDS layout contexts that paint their own dark
+// surface: the hero callout and .usa-section--dark, which the
+// graphic list sits on in the USWDS landing page template.
+//
+// USWDS fills both with color("primary-darker") and colors the
+// headings inside them with color("accent-cool"). Under the HDS
+// theme that reads as a NASA-red block with cyan headings, so
+// base/_palettes.scss maps both surfaces onto the HDS dark
+// palette instead (Issue #148).
+//
+// The palette story is the regression guard. It renders the same
+// markup inside all six palette wrappers — the surfaces are
+// expected to stay dark in every one — and axe-core checks the
+// contrast of every heading, paragraph, link, and button that
+// sits on them.
+// ============================================================
+
+import { paletteA11yParams, paletteRender } from '../helpers/paletteTests';
+
+export default {
+  title: 'Guides/Existing USWDS Site/Dark Sections',
+  parameters: {
+    layout: 'fullscreen',
+    options: { showPanel: false },
+  },
+};
+
+const hero = `
+  <section class="usa-hero" aria-label="Introduction">
+    <div class="grid-container">
+      <div class="usa-hero__callout">
+        <h1 class="usa-hero__heading">
+          <span class="usa-hero__heading--alt">Hero callout:</span>Bring
+          attention to a project priority
+        </h1>
+        <p>
+          Support the callout with some short explanatory text. You don't need
+          more than a couple of sentences.
+        </p>
+        <a class="usa-button" href="#">Call to action</a>
+      </div>
+    </div>
+  </section>
+`;
+
+const graphicList = `
+  <section class="usa-graphic-list usa-section usa-section--dark">
+    <div class="grid-container">
+      <div class="usa-graphic-list__row grid-row grid-gap">
+        <div class="usa-media-block tablet:grid-col">
+          <img class="usa-media-block__img" src="assets/img/circle-124.png" alt="" />
+          <div class="usa-media-block__body">
+            <h2 class="usa-graphic-list__heading">Graphic headings can vary.</h2>
+            <p>
+              Graphic headings can be used a few different ways, depending on
+              what your landing page is for.
+            </p>
+            <a class="usa-link" href="#">Read the mission overview</a>
+          </div>
+        </div>
+        <div class="usa-media-block tablet:grid-col">
+          <img class="usa-media-block__img" src="assets/img/circle-124.png" alt="" />
+          <div class="usa-media-block__body">
+            <h2 class="usa-graphic-list__heading">Stick to 6 or fewer words.</h2>
+            <p>
+              Buttons and links inside the section pick up the same dark
+              treatment as the surface they sit on.
+            </p>
+            <a class="usa-button" href="#">Call to action</a>
+            <a class="usa-button usa-button--outline" href="#">On-page action</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+`;
+
+export const DarkSections = {
+  name: 'Hero and dark section',
+  render: () => `${hero}${graphicList}`,
+};
+
+export const PaletteA11y = {
+  name: 'Palette a11y',
+  tags: ['!dev'],
+  parameters: paletteA11yParams,
+  render: paletteRender(DarkSections.render),
+};

--- a/stories/guides/USWDSLandingPage.stories.js
+++ b/stories/guides/USWDSLandingPage.stories.js
@@ -17,6 +17,11 @@
 // yet. They render as stock USWDS, pinned to the palette that
 // matches the surface USWDS paints (see base/_palettes.scss) so
 // they stay readable in every palette mode.
+//
+// The hero callout and the graphic list's dark section paint
+// their own surface in USWDS and land on the HDS dark palette
+// instead of USWDS primary-darker (Issue #148). The Dark
+// Sections story covers those two on their own.
 // ============================================================
 
 import { paletteModes } from '../../.storybook/modes';

--- a/stories/guides/USWDSLandingPage.stories.js
+++ b/stories/guides/USWDSLandingPage.stories.js
@@ -36,9 +36,6 @@ export default {
       delay: 300,
       modes: paletteModes,
     },
-    a11y: {
-      test: 'todo',
-    },
   },
 };
 


### PR DESCRIPTION
## What this PR does

I picked this up from #148, and the first thing I did was build the CSS and drop the untouched USWDS landing page template on top of it, because I wanted to see the thing with my own eyes before deciding anything. The issue undersells it a little. The hero callout is a slab of dark red with a cyan headline sitting on it, there's a red button on the red box, and further down the graphic list sits on the same red with more cyan. Nothing else in HDS looks remotely like that. If I were a team migrating a site over from USWDS, this is one of the first screens I'd see, and I'd probably conclude the theme was broken and go file a ticket — which is roughly what happened here.

The cause is short. USWDS paints both of its dark layout contexts — `.usa-hero__callout` and `.usa-section--dark` — with `color("primary-darker")`, and colors the headings inside them with `color("accent-cool")`. HDS maps the primary family to NASA Red, and accent-cool is a family HDS never themes at all, so the red and the cyan both come straight through untouched.

This PR maps both surfaces onto palette 4 (dark, Carbon 90), so everything sitting on them — headings, body copy, links, buttons, focus rings — resolves against the surface it's actually on.

Closes #148

## The part I got wrong first

My instinct was the lazy one: this is exactly what the palette system is for, so just tell adopters to wrap the section in `.hds-palette-dark` and close the issue with a docs change. I'm glad I tried it before writing it down, because it doesn't work, and the reason is the whole reason this fix has to live in the framework instead of the guide.

The red isn't a palette custom property. It's a plain `background-color` on the component itself, so no ancestor wrapper can reach it. And when I wrapped it anyway, `.hds-palette-white` made things actively worse — the headings gave up their cyan and became Carbon Black on the red block. So the advice we'd have been handing adopters was "add this class and it gets harder to read."

Then I stopped eyeballing it and measured what was actually shipping. A couple of these were worse than I expected:

| Element | Before | After |
| --- | --- | --- |
| Surface | USWDS `primary-darker` `#8b0a03` | Carbon 90 `#17171b` |
| Headings on those surfaces | `accent-cool` `#00bde3`, 4.38:1 | `--hds-palette-heading` white, 17.9:1 |
| Hero `--alt` eyebrow | White — fine on its own, but it's the line that gets flattened once the cyan goes | `--hds-palette-muted` Carbon 30, 9.1:1 |
| `.usa-link` in a dark section | Carbon 90 on red, **1.8:1** | White, 17.9:1 |
| `.usa-button--outline` label | Carbon Black on red, **2.1:1** | White, 17.9:1 |
| `.usa-button` on the hero callout | `#d83933` on `#8b0a03` — **2.1:1** against its own container | `#d83933` on Carbon 90, 3.9:1 |

The three in bold fail WCAG 2.1 AA. The link one in particular bothered me: 1.8:1 is not "a bit low," it's a link you cannot see. That happens because an HDS component dropped inside a USWDS dark section is still reading white-palette values — nothing ever told it the ground underneath it had changed color.

## What I chose, and why

I deliberately didn't invent anything. HDS already has a designed dark surface, and it already knows how to relate every token to it, so I mapped the two USWDS contexts onto that rather than picking a new dark red or a new neutral. It means no new colors enter the system, and adopters get correct behaviour on markup they already shipped without going back and adding classes to it.

I kept the selectors inside `:where()` so they carry zero specificity. If a team wants a different surface there, they drop `.hds-palette-blue` on the same element and win, no `!important` needed. That's the same contract as the USWDS surface bridges that already live directly above this block in `base/_palettes.scss` — I tried hard to make this read like it belongs next to them rather than like something bolted on afterwards.

Two things I chose *not* to touch, in case it looks like an oversight. USWDS pins `<p>` and `<a>` inside `.usa-section--dark` to white on the elements themselves; I left those alone, because white is what the dark scheme resolves to anyway, and the blue palette — the other surface someone would plausibly swap in on a section marked dark — is also dark with white body text. And `.usa-section--light` is untouched: USWDS paints it `base-lightest`, which the HDS theme already maps to white, so it agrees with the default palette without help.

## The bit I'm least sure about

The USWDS hero heading is two-tone: a small `--alt` eyebrow above the statement line. Once the cyan is gone, painting both with the heading color flattens it into one undifferentiated block of white, and the design intent of the component quietly disappears.

I gave the eyebrow the muted token HDS already uses for overlines and metadata (Carbon 30, 9.1:1 on Carbon 90). It reads well and it keeps the hierarchy, but I want to be honest that this is a design call and not a contrast fix, so I've written it up in `docs/DESIGN.md` under Creative Director Review rather than burying it. If design would rather the eyebrow stay full white, or take a different treatment entirely, it's one declaration to change and I'll happily change it.

## Something I nearly shipped a bug on

Themed dark surfaces created a print problem I didn't see coming and only caught because I ran the page through print emulation on a whim.

Browsers drop background colors when printing, so white text on those sections would have printed as a blank page. The existing reset in `base/_print.scss` only covers palette containers, and these two aren't palette containers — they carry the dark scheme without being one — so they're now listed there too. USWDS pins those `<p>` and `<a>` colors on the elements themselves, where the reset only reached them by inheritance and lost, so those get an explicit black.

## Type of change

- [ ] Bug fix (patch)
- [x] New feature or component (minor)
- [ ] Breaking change (see Public API section below)
- [ ] Documentation only
- [ ] Tooling or CI (no effect on published output)

I went back and forth on patch vs minor. It's a fix in intent, but it visibly changes markup adopters already have on their pages, and the [semver rubric](https://github.com/nasa/hds-core/blob/main/CONTRIBUTING.md#semver-rubric) treats that as a visible change rather than a silent correction — so, minor. Push back if you read the rubric differently.

## Checklist

- [x] `npm run format:fix` and `npm run lint:scss:fix` pass
- [x] `npm run lint:js` and `npm run lint:md` pass
- [x] Tested across all 6 palettes in Storybook
- [x] Tested across mobile, tablet, and desktop viewports
- [x] Automated a11y checks pass (`npm test`)
- [x] Storybook documentation updated (if component changed)

I don't like ticking boxes without saying what's behind them, so:

The new `PaletteA11y` story renders the hero and the dark section inside all six palettes and runs axe across the lot. Viewports I checked by hand at 320, 640 and 1024 — the callout goes full-bleed on mobile and the graphic list collapses to one column, and both keep the surface and stay readable.

The a11y one I want to flag specifically. A test that passes tells you nothing until you've watched it fail, so I reverted the SCSS and re-ran the suite to make sure the new story actually catches this bug rather than just going green next to it. On the pre-fix CSS it fails on `color-contrast` for `.usa-hero__heading` (2.14:1) and `.usa-button--outline` (2.14:1). Reapplied the fix, clean. That's the bit that makes me comfortable this regression can't quietly come back.

Docs went to `docs/DESIGN.md` (rationale, before/after, the design question flagged), `docs/ARCHITECTURE.md` (why layer order handles this without specificity tricks, plus the print note), `stories/guides/USWDS.mdx` (adopters no longer need to hand-wrap these two, but other dark contexts like `.usa-dark-background` still need it), and `AGENTS.md` so nobody — me included, six months from now — "simplifies" this away without knowing what it was for.

## Public API and changesets

- [x] Ran `npm run update:api-snapshot` and reviewed the diff
- [x] Changeset added (`npx changeset`) with appropriate bump level
- [x] Bump level matches the [semver rubric](https://github.com/nasa/hds-core/blob/main/CONTRIBUTING.md#semver-rubric)

The snapshot picks up three selectors: `.usa-hero__callout`, `.usa-hero__heading--alt`, `.usa-section--dark`. No new Sass symbols, so the public Sass surface is unchanged.

## Visual review

Storybook: **Guides → Existing USWDS Site → Dark Sections** is the focused case, and **Landing Page** shows both surfaces in the full USWDS template if you want to see them in context.

<!-- Attach before/after screenshots of the Dark Sections story here. -->

## Notes for reviewers

The eyebrow color is the one open question; everything else is built from tokens that already exist, so it should be uncontroversial, but I'd rather you tell me than assume.

Worth saying out loud: this will visibly change any site currently shipping a USWDS hero callout or `.usa-section--dark` under HDS. Red block becomes Carbon 90. That's the point of the issue, but somebody will notice it in a release, so the changeset says so plainly.

On the `status:needs-design-review` label — I read that as "the color decision needs a designer to sign off," not "don't touch this yet," so I've put forward a specific answer assembled entirely from existing tokens rather than leaving it open. If that was the wrong read, tell me and I'll pull it back to a proposal. If design wants a different surface, it's one block in `base/_palettes.scss`.

Scope I deliberately left alone: other USWDS dark contexts like `.usa-dark-background` and custom section modifiers. Those still need an adopter-applied palette class. I kept this to the two surfaces named in the issue rather than expanding it on my own initiative — happy to follow up in a separate PR if you'd like the same treatment there.
