### PR TITLE
fix: use palette variable for button hover states

### DIFF
--- a/src/scss/_hds-mixins.scss
+++ b/src/scss/_hds-mixins.scss
@@ -243,7 +243,7 @@ $_focus-ring-rect-svg: "data:image/svg+xml,%3Csvg width='100%25' height='100%25'
 @mixin button-interactive-states {
   &:hover:not(:disabled, [aria-disabled='true']),
   &:active:not(:disabled, [aria-disabled='true']) {
-    background-color: $hds-color-nasa-red-shade;
+    background-color: var(--hds-palette-btn-primary-bg-hover, #{$hds-color-nasa-red-shade});
     text-decoration-line: none;
   }
 


### PR DESCRIPTION
## Description

The `@mixin button-interactive-states` in `src/scss/_hds-mixins.scss` was hardcoding the background color for hover and active states to a Sass variable (`$hds-color-nasa-red-shade`) instead of using the palette CSS custom property. 

This flattened the palette system. If a button was placed inside an alternative palette wrapper (e.g., the Blue palette), it incorrectly turned NASA Red on hover instead of using the active palette's hover color. This PR updates it to use `var(--hds-palette-btn-primary-bg-hover)` with the original red shade as a fallback.

Closes #202

## Type of change

<!-- Check one. Must match the changeset bump below. -->

- [x] Bug fix (patch)
- [ ] New feature or component (minor)
- [ ] Breaking change (see Public API note below)
- [ ] Documentation only
- [ ] Tooling or CI (no effect on published CSS)

## How to review

Open the Button component in Storybook and change the active palette wrapper (e.g., to the Blue or Dark palette). Hover over the button and verify that the background color correctly matches the hover color defined by the surrounding palette rather than forcing NASA Red.

## Before requesting review

<!-- Running the automated checks locally saves a failed-check round-trip:
CI hard-fails on them. The rest need a human; CI can't verify them.
Full command list: CONTRIBUTING.md. -->

- [x] `npm run lint`, `npm run format`, and `npm test` pass locally

**If your change affects how anything renders (styles, tokens, story markup, icons, or fonts):**

- [x] Checked across all 6 palettes in Storybook
- [x] Checked across mobile, tablet, and desktop viewports
- [x] Did a manual a11y pass (keyboard, focus, screen-reader labels)

**If your change ships in the package (styles, tokens, or `src/assets/**`):**

- [x] Added a changeset (`npm run changeset`) or verified this change doesn't need one
